### PR TITLE
Implement PostgresAdapter user mapping

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -7,17 +7,25 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.UUID;
 
 @Component
 public class PostgresAdapter implements ListUsersPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
+    private final UserRepository userRepository;
+
+    public PostgresAdapter(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
     @Override
     public List<User> listUsers() {
         logger.debug("postgress query...");
-        return List.of(new User(UUID.randomUUID(), "Pepe"));
+
+        return userRepository.findAll().stream()
+                .map(user -> new User(user.getId(), user.getName()))
+                .toList();
     }
 
 }


### PR DESCRIPTION
## Summary
- Map database entities to domain users in `PostgresAdapter`
- Inject `UserRepository` to retrieve and convert persisted users

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1efcd5c483298b02c7656e05fa32