### PR TITLE
feat: add create user endpoint

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/UserController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/UserController.java
@@ -1,11 +1,15 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
+import com.xavelo.template.render.api.application.port.in.CreateUserUseCase;
 import com.xavelo.template.render.api.application.port.in.ListUsersUseCase;
 import com.xavelo.template.render.api.domain.User;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,15 +22,23 @@ public class UserController {
     private static final Logger logger = LogManager.getLogger(UserController.class);
 
     private final ListUsersUseCase listUsersUseCase;
+    private final CreateUserUseCase createUserUseCase;
 
-    public UserController(ListUsersUseCase listUsersUseCase) {
+    public UserController(ListUsersUseCase listUsersUseCase, CreateUserUseCase createUserUseCase) {
         this.listUsersUseCase = listUsersUseCase;
+        this.createUserUseCase = createUserUseCase;
     }
 
     @GetMapping("/users")
     public ResponseEntity<List<User>> latencySync() {
         List<User> users = listUsersUseCase.listUsers();
         return ResponseEntity.ok(users);
+    }
+
+    @PostMapping("/users")
+    public ResponseEntity<User> createUser(@RequestBody User user) {
+        User savedUser = createUserUseCase.createUser(user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
     }
 
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -1,5 +1,6 @@
 package com.xavelo.template.render.api.adapter.out.jdbc;
 
+import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.domain.User;
 import org.slf4j.Logger;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class PostgresAdapter implements ListUsersPort {
+public class PostgresAdapter implements ListUsersPort, CreateUserPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
@@ -26,6 +27,19 @@ public class PostgresAdapter implements ListUsersPort {
         return userRepository.findAll().stream()
                 .map(user -> new User(user.getId(), user.getName()))
                 .toList();
+    }
+
+    @Override
+    public User createUser(User user) {
+        logger.debug("postgress insert...");
+
+        com.xavelo.template.render.api.adapter.out.jdbc.User userEntity =
+                new com.xavelo.template.render.api.adapter.out.jdbc.User();
+        userEntity.setName(user.name());
+
+        com.xavelo.template.render.api.adapter.out.jdbc.User savedUser = userRepository.save(userEntity);
+
+        return new User(savedUser.getId(), savedUser.getName());
     }
 
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/CreateUserUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/CreateUserUseCase.java
@@ -1,0 +1,8 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.User;
+
+public interface CreateUserUseCase {
+    User createUser(User user);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/CreateUserPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/CreateUserPort.java
@@ -1,0 +1,8 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.User;
+
+public interface CreateUserPort {
+    User createUser(User user);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/service/UserService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/UserService.java
@@ -1,6 +1,8 @@
 package com.xavelo.template.render.api.application.service;
 
+import com.xavelo.template.render.api.application.port.in.CreateUserUseCase;
 import com.xavelo.template.render.api.application.port.in.ListUsersUseCase;
+import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.domain.User;
 import org.springframework.stereotype.Service;
@@ -8,17 +10,24 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
-public class UserService implements ListUsersUseCase {
+public class UserService implements ListUsersUseCase, CreateUserUseCase {
 
-    private ListUsersPort listUsersPort;
+    private final ListUsersPort listUsersPort;
+    private final CreateUserPort createUserPort;
 
-    public UserService(ListUsersPort listUsersPort) {
+    public UserService(ListUsersPort listUsersPort, CreateUserPort createUserPort) {
         this.listUsersPort = listUsersPort;
+        this.createUserPort = createUserPort;
     }
 
     @Override
     public List<User> listUsers() {
         return listUsersPort.listUsers();
+    }
+
+    @Override
+    public User createUser(User user) {
+        return createUserPort.createUser(user);
     }
 
 }


### PR DESCRIPTION
## Summary
- add CreateUserUseCase and CreateUserPort to define user creation flow
- implement persistence and service layers for creating users
- expose POST /api/users endpoint to create users
- return HTTP 201 status for successful user creation

## Testing
- `mvn -q test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68bb20814de483298a2a45123d3ab85a