### PR TITLE
Add Flyway migration for user table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.flywaydb</groupId>
+                        <artifactId>flyway-core</artifactId>
+                </dependency>
 		<!-- Spring Ssecurity -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,10 +14,12 @@ spring:
     username: poc_v5zu_user
     password: MnqkDSjJUnmuPke56CUsGpfDA9oa5pPO
     driver-class-name: org.postgresql.Driver
+  flyway:
+    locations: classpath:db/migration
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update   # create|create-drop|update|validate|none
+      ddl-auto: validate   # create|create-drop|update|validate|none
     show-sql: true
     properties:
       hibernate.format_sql: true

--- a/src/main/resources/db/migration/V1__create_user_table.sql
+++ b/src/main/resources/db/migration/V1__create_user_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "user" (
+    id UUID PRIMARY KEY,
+    name VARCHAR(50) NOT NULL
+);


### PR DESCRIPTION
## Summary
- integrate Flyway for database migrations
- configure Flyway and JPA settings
- add initial migration to create `user` table

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb45f1d2888329bc24b0e4c619fa46