### PR TITLE
Add endpoint to fetch user by id

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/UserController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/UserController.java
@@ -1,15 +1,18 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
+import com.xavelo.template.render.api.application.port.in.GetUserUseCase;
 import com.xavelo.template.render.api.application.port.in.ListUsersUseCase;
 import com.xavelo.template.render.api.domain.User;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api")
@@ -18,15 +21,24 @@ public class UserController {
     private static final Logger logger = LogManager.getLogger(UserController.class);
 
     private final ListUsersUseCase listUsersUseCase;
+    private final GetUserUseCase getUserUseCase;
 
-    public UserController(ListUsersUseCase listUsersUseCase) {
+    public UserController(ListUsersUseCase listUsersUseCase, GetUserUseCase getUserUseCase) {
         this.listUsersUseCase = listUsersUseCase;
+        this.getUserUseCase = getUserUseCase;
     }
 
     @GetMapping("/users")
-    public ResponseEntity<List<User>> latencySync() {
+    public ResponseEntity<List<User>> listUsers() {
         List<User> users = listUsersUseCase.listUsers();
         return ResponseEntity.ok(users);
     }
 
+    @GetMapping("/user/{id}")
+    public ResponseEntity<User> getUser(@PathVariable UUID id) {
+        return getUserUseCase.getUser(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
 }
+

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -1,5 +1,6 @@
 package com.xavelo.template.render.api.adapter.out.jdbc;
 
+import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.domain.User;
 import org.slf4j.Logger;
@@ -7,10 +8,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Component
-public class PostgresAdapter implements ListUsersPort {
+public class PostgresAdapter implements ListUsersPort, GetUserPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
@@ -29,4 +31,10 @@ public class PostgresAdapter implements ListUsersPort {
                 .toList();
     }
 
+    @Override
+    public Optional<User> getUser(UUID id) {
+        return userRepository.findById(id)
+                .map(user -> new User(user.getId(), user.getName()));
+    }
 }
+

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/GetUserUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/GetUserUseCase.java
@@ -1,0 +1,11 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetUserUseCase {
+    Optional<User> getUser(UUID id);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/GetUserPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/GetUserPort.java
@@ -1,0 +1,11 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetUserPort {
+    Optional<User> getUser(UUID id);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/service/UserService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/UserService.java
@@ -1,25 +1,35 @@
 package com.xavelo.template.render.api.application.service;
 
+import com.xavelo.template.render.api.application.port.in.GetUserUseCase;
 import com.xavelo.template.render.api.application.port.in.ListUsersUseCase;
+import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.domain.User;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
-public class UserService implements ListUsersUseCase {
+public class UserService implements ListUsersUseCase, GetUserUseCase {
 
-    private ListUsersPort listUsersPort;
+    private final ListUsersPort listUsersPort;
+    private final GetUserPort getUserPort;
 
-    public UserService(ListUsersPort listUsersPort) {
+    public UserService(ListUsersPort listUsersPort, GetUserPort getUserPort) {
         this.listUsersPort = listUsersPort;
+        this.getUserPort = getUserPort;
     }
 
     @Override
     public List<User> listUsers() {
-        //return List.of();
         return listUsersPort.listUsers();
     }
 
+    @Override
+    public Optional<User> getUser(UUID id) {
+        return getUserPort.getUser(id);
+    }
 }
+


### PR DESCRIPTION
## Summary
- support listing users and fetching a single user by id
- wire up new in/out ports and service methods for user retrieval
- expose GET /api/user/{id}

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb53b037f483299f52fe75f265338e