### PR TITLE
Generate user IDs server-side

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateUserRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateUserRequest.java
@@ -1,0 +1,3 @@
+package com.xavelo.template.render.api.adapter.in.http.secure;
+
+public record CreateUserRequest(String name) {}

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/UserController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/UserController.java
@@ -41,8 +41,8 @@ public class UserController {
     }
 
     @PostMapping("/user")
-    public ResponseEntity<User> createUser(@RequestBody User user) {
-        User savedUser = createUserUseCase.createUser(user);
+    public ResponseEntity<User> createUser(@RequestBody CreateUserRequest request) {
+        User savedUser = createUserUseCase.createUser(request.name());
         return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
     }
 

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/CreateUserUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/CreateUserUseCase.java
@@ -3,6 +3,6 @@ package com.xavelo.template.render.api.application.port.in;
 import com.xavelo.template.render.api.domain.User;
 
 public interface CreateUserUseCase {
-    User createUser(User user);
+    User createUser(String name);
 }
 

--- a/src/main/java/com/xavelo/template/render/api/application/service/UserService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/UserService.java
@@ -1,10 +1,9 @@
 package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.in.CreateUserUseCase;
-import com.xavelo.template.render.api.application.port.in.ListUsersUseCase;
-import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.in.GetUserUseCase;
 import com.xavelo.template.render.api.application.port.in.ListUsersUseCase;
+import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.domain.User;
@@ -33,7 +32,8 @@ public class UserService implements ListUsersUseCase, CreateUserUseCase, GetUser
     }
 
     @Override
-    public User createUser(User user) {
+    public User createUser(String name) {
+        User user = new User(UUID.randomUUID(), name);
         return createUserPort.createUser(user);
     }
 


### PR DESCRIPTION
## Summary
- Create `CreateUserRequest` DTO for user creation
- Generate user UUIDs in `UserService`
- Simplify `POST /user` to accept only a name

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4534f54883298522a6345e3ce022