### PR TITLE
Add authorization table migration

### DIFF
--- a/src/main/resources/db/migration/V3__create_authorization_table.sql
+++ b/src/main/resources/db/migration/V3__create_authorization_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "authorization" (
+    id UUID PRIMARY KEY,
+    title VARCHAR NOT NULL,
+    text TEXT NOT NULL,
+    status VARCHAR NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR NOT NULL,
+    sent_at TIMESTAMPTZ,
+    sent_by VARCHAR,
+    approved_at TIMESTAMPTZ,
+    approved_by VARCHAR
+);


### PR DESCRIPTION
## Summary
- create Flyway migration for authorization table
- remove database default for authorization id

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4acb8270832987de1aa77dceed87