### PR TITLE
feat: add guardian entity and controller

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateGuardianRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateGuardianRequest.java
@@ -1,0 +1,3 @@
+package com.xavelo.template.render.api.adapter.in.http.secure;
+
+public record CreateGuardianRequest(String name) {}

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
@@ -1,0 +1,27 @@
+package com.xavelo.template.render.api.adapter.in.http.secure;
+
+import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
+import com.xavelo.template.render.api.domain.Guardian;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class GuardianController {
+
+    private final CreateGuardianUseCase createGuardianUseCase;
+
+    public GuardianController(CreateGuardianUseCase createGuardianUseCase) {
+        this.createGuardianUseCase = createGuardianUseCase;
+    }
+
+    @PostMapping("/guardian")
+    public ResponseEntity<Guardian> createGuardian(@RequestBody CreateGuardianRequest request) {
+        Guardian saved = createGuardianUseCase.createGuardian(request.name());
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+}

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Guardian.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Guardian.java
@@ -1,0 +1,36 @@
+package com.xavelo.template.render.api.adapter.out.jdbc;
+
+import jakarta.persistence.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(name = "\"guardian\"")
+public class Guardian implements Serializable {
+
+    @Id
+    @GeneratedValue
+    @org.hibernate.annotations.UuidGenerator
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/GuardianRepository.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/GuardianRepository.java
@@ -1,0 +1,10 @@
+package com.xavelo.template.render.api.adapter.out.jdbc;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface GuardianRepository extends JpaRepository<Guardian, UUID> {
+}

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -2,12 +2,14 @@ package com.xavelo.template.render.api.adapter.out.jdbc;
 
 import com.xavelo.template.render.api.application.port.out.CreateAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
+import com.xavelo.template.render.api.application.port.out.CreateGuardianPort;
 import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.domain.Authorization;
 import com.xavelo.template.render.api.domain.Student;
 import com.xavelo.template.render.api.domain.User;
+import com.xavelo.template.render.api.domain.Guardian;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -17,20 +19,23 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Component
-public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort {
+public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort, CreateGuardianPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
     private final UserRepository userRepository;
     private final AuthorizationRepository authorizationRepository;
     private final StudentRepository studentRepository;
+    private final GuardianRepository guardianRepository;
 
     public PostgresAdapter(UserRepository userRepository,
                            AuthorizationRepository authorizationRepository,
-                           StudentRepository studentRepository) {
+                           StudentRepository studentRepository,
+                           GuardianRepository guardianRepository) {
         this.userRepository = userRepository;
         this.authorizationRepository = authorizationRepository;
         this.studentRepository = studentRepository;
+        this.guardianRepository = guardianRepository;
     }
 
     @Override
@@ -87,6 +92,19 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         com.xavelo.template.render.api.adapter.out.jdbc.Student saved = studentRepository.save(entity);
 
         return new Student(saved.getId(), saved.getName());
+    }
+
+    @Override
+    public Guardian createGuardian(Guardian guardian) {
+        logger.debug("postgress insert guardian...");
+
+        com.xavelo.template.render.api.adapter.out.jdbc.Guardian entity =
+                new com.xavelo.template.render.api.adapter.out.jdbc.Guardian();
+        entity.setName(guardian.name());
+
+        com.xavelo.template.render.api.adapter.out.jdbc.Guardian saved = guardianRepository.save(entity);
+
+        return new Guardian(saved.getId(), saved.getName());
     }
 
     public Optional<User> getUser(UUID id) {

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/CreateGuardianUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/CreateGuardianUseCase.java
@@ -1,0 +1,7 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+public interface CreateGuardianUseCase {
+    Guardian createGuardian(String name);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/CreateGuardianPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/CreateGuardianPort.java
@@ -1,0 +1,7 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+public interface CreateGuardianPort {
+    Guardian createGuardian(Guardian guardian);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
@@ -1,0 +1,24 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
+import com.xavelo.template.render.api.application.port.out.CreateGuardianPort;
+import com.xavelo.template.render.api.domain.Guardian;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class GuardianService implements CreateGuardianUseCase {
+
+    private final CreateGuardianPort createGuardianPort;
+
+    public GuardianService(CreateGuardianPort createGuardianPort) {
+        this.createGuardianPort = createGuardianPort;
+    }
+
+    @Override
+    public Guardian createGuardian(String name) {
+        Guardian guardian = new Guardian(UUID.randomUUID(), name);
+        return createGuardianPort.createGuardian(guardian);
+    }
+}

--- a/src/main/java/com/xavelo/template/render/api/domain/Guardian.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Guardian.java
@@ -1,0 +1,5 @@
+package com.xavelo.template.render.api.domain;
+
+import java.util.UUID;
+
+public record Guardian(UUID id, String name) {}

--- a/src/main/resources/db/migration/V4__create_guardian_table.sql
+++ b/src/main/resources/db/migration/V4__create_guardian_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "guardian" (
+    id UUID PRIMARY KEY,
+    name VARCHAR(50) NOT NULL
+);


### PR DESCRIPTION
## Summary
- introduce Guardian domain, service, and REST controller
- persist guardians via JDBC adapter and migration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4dec67a883298350a5c363d82932