### PR TITLE
Mock PostgresAdapter in context-load test

### DIFF
--- a/src/test/java/com/xavelo/template/TemplateApiRenderApplicationTests.java
+++ b/src/test/java/com/xavelo/template/TemplateApiRenderApplicationTests.java
@@ -1,22 +1,26 @@
 package com.xavelo.template;
 
+import com.xavelo.template.render.api.adapter.out.jdbc.PostgresAdapter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
+@SpringBootTest
 class TemplateApiRenderApplicationTests {
 
-	@Autowired
-	private ApplicationContext applicationContext;
+    @MockBean
+    private PostgresAdapter postgresAdapter;
 
-	@Test
-	void contextLoads() {
-		assertNotNull(applicationContext);
-	}
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void contextLoads() {
+        assertNotNull(applicationContext);
+    }
 
 }


### PR DESCRIPTION
## Summary
- Mock PostgresAdapter in TemplateApiRenderApplicationTests to avoid repository creation
- Remove DataSource auto-configuration exclusion

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc591f5b0c8329be3c3427e9e029db