### PR TITLE
Allow optional guardian IDs when creating students

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateStudentRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateStudentRequest.java
@@ -1,3 +1,6 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
-public record CreateStudentRequest(String name) {}
+import java.util.List;
+import java.util.UUID;
+
+public record CreateStudentRequest(String name, List<UUID> guardianIds) {}

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentController.java
@@ -21,7 +21,7 @@ public class StudentController {
 
     @PostMapping("/student")
     public ResponseEntity<Student> createStudent(@RequestBody CreateStudentRequest request) {
-        Student saved = createStudentUseCase.createStudent(request.name());
+        Student saved = createStudentUseCase.createStudent(request.name(), request.guardianIds());
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -1,9 +1,10 @@
 package com.xavelo.template.render.api.adapter.out.jdbc;
 
 import com.xavelo.template.render.api.application.port.out.CreateAuthorizationPort;
-import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
 import com.xavelo.template.render.api.application.port.out.CreateGuardianPort;
+import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
 import com.xavelo.template.render.api.application.port.out.CreateUserPort;
+import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.domain.Authorization;
@@ -14,12 +15,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Component
-public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort, CreateGuardianPort {
+public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort, CreateGuardianPort, GetGuardianPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
@@ -89,9 +91,18 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
                 new com.xavelo.template.render.api.adapter.out.jdbc.Student();
         entity.setName(student.name());
 
+        if (student.guardianIds() != null && !student.guardianIds().isEmpty()) {
+            List<com.xavelo.template.render.api.adapter.out.jdbc.Guardian> guardians =
+                    guardianRepository.findAllById(student.guardianIds());
+            entity.setGuardians(new HashSet<>(guardians));
+        }
+
         com.xavelo.template.render.api.adapter.out.jdbc.Student saved = studentRepository.save(entity);
 
-        return new Student(saved.getId(), saved.getName());
+        List<UUID> guardianIds = saved.getGuardians().stream()
+                .map(com.xavelo.template.render.api.adapter.out.jdbc.Guardian::getId)
+                .toList();
+        return new Student(saved.getId(), saved.getName(), guardianIds);
     }
 
     @Override
@@ -110,6 +121,12 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
     public Optional<User> getUser(UUID id) {
         return userRepository.findById(id)
                 .map(user -> new User(user.getId(), user.getName()));
+    }
+
+    @Override
+    public Optional<Guardian> getGuardian(UUID id) {
+        return guardianRepository.findById(id)
+                .map(g -> new Guardian(g.getId(), g.getName()));
     }
 
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Student.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Student.java
@@ -3,6 +3,8 @@ package com.xavelo.template.render.api.adapter.out.jdbc;
 import jakarta.persistence.*;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -18,6 +20,12 @@ public class Student implements Serializable {
     @Column(name = "name", length = 50, nullable = false)
     private String name;
 
+    @ManyToMany
+    @JoinTable(name = "\"student_guardian\"",
+            joinColumns = @JoinColumn(name = "student_id"),
+            inverseJoinColumns = @JoinColumn(name = "guardian_id"))
+    private Set<Guardian> guardians = new HashSet<>();
+
     public UUID getId() {
         return id;
     }
@@ -32,5 +40,13 @@ public class Student implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Set<Guardian> getGuardians() {
+        return guardians;
+    }
+
+    public void setGuardians(Set<Guardian> guardians) {
+        this.guardians = guardians;
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/CreateStudentUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/CreateStudentUseCase.java
@@ -2,6 +2,9 @@ package com.xavelo.template.render.api.application.port.in;
 
 import com.xavelo.template.render.api.domain.Student;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface CreateStudentUseCase {
-    Student createStudent(String name);
+    Student createStudent(String name, List<UUID> guardianIds);
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/GetGuardianPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/GetGuardianPort.java
@@ -1,0 +1,10 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetGuardianPort {
+    Optional<Guardian> getGuardian(UUID id);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/service/StudentService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/StudentService.java
@@ -5,6 +5,8 @@ import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
 import com.xavelo.template.render.api.domain.Student;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -17,8 +19,9 @@ public class StudentService implements CreateStudentUseCase {
     }
 
     @Override
-    public Student createStudent(String name) {
-        Student student = new Student(UUID.randomUUID(), name);
+    public Student createStudent(String name, List<UUID> guardianIds) {
+        List<UUID> ids = guardianIds != null ? guardianIds : Collections.emptyList();
+        Student student = new Student(UUID.randomUUID(), name, ids);
         return createStudentPort.createStudent(student);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/domain/Student.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Student.java
@@ -1,5 +1,6 @@
 package com.xavelo.template.render.api.domain;
 
+import java.util.List;
 import java.util.UUID;
 
-public record Student(UUID id, String name) {}
+public record Student(UUID id, String name, List<UUID> guardianIds) {}

--- a/src/main/resources/db/migration/V6__create_student_guardian_table.sql
+++ b/src/main/resources/db/migration/V6__create_student_guardian_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS "student_guardian" (
+    student_id UUID NOT NULL,
+    guardian_id UUID NOT NULL,
+    PRIMARY KEY (student_id, guardian_id),
+    CONSTRAINT fk_student FOREIGN KEY (student_id) REFERENCES "student"(id),
+    CONSTRAINT fk_guardian FOREIGN KEY (guardian_id) REFERENCES "guardian"(id)
+);

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentControllerTest.java
@@ -1,0 +1,56 @@
+package com.xavelo.template.render.api.adapter.in.http.secure;
+
+import com.xavelo.template.render.api.application.port.in.CreateStudentUseCase;
+import com.xavelo.template.render.api.domain.Student;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreateStudentUseCase createStudentUseCase;
+
+    @Test
+    void whenNoGuardianIds_thenReturnsCreated() throws Exception {
+        Student student = new Student(UUID.randomUUID(), "John", List.of());
+        Mockito.when(createStudentUseCase.createStudent(any(), anyList()))
+                .thenReturn(student);
+
+        String json = "{ \"name\": \"John\" }";
+        mockMvc.perform(post("/api/student")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void whenValidRequestWithGuardianIds_thenReturnsCreated() throws Exception {
+        UUID guardianId = UUID.randomUUID();
+        Student student = new Student(UUID.randomUUID(), "John", List.of(guardianId));
+        Mockito.when(createStudentUseCase.createStudent(any(), anyList()))
+                .thenReturn(student);
+
+        String json = "{ \"name\": \"John\", \"guardianIds\": [\"" + guardianId + "\"] }";
+        mockMvc.perform(post("/api/student")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/xavelo/template/render/api/application/service/StudentServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/StudentServiceTest.java
@@ -1,0 +1,37 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
+import com.xavelo.template.render.api.domain.Student;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+class StudentServiceTest {
+
+    private final CreateStudentPort createStudentPort = Mockito.mock(CreateStudentPort.class);
+    private final StudentService studentService = new StudentService(createStudentPort);
+
+    @Test
+    void whenCreatingStudentWithoutGuardians_thenCreatesStudent() {
+        Student student = new Student(UUID.randomUUID(), "John", List.of());
+        Mockito.when(createStudentPort.createStudent(any(Student.class))).thenReturn(student);
+
+        Student result = studentService.createStudent("John", List.of());
+        assertEquals(student, result);
+    }
+
+    @Test
+    void whenCreatingStudentWithGuardians_thenCreatesStudent() {
+        UUID guardianId = UUID.randomUUID();
+        Student student = new Student(UUID.randomUUID(), "John", List.of(guardianId));
+        Mockito.when(createStudentPort.createStudent(any(Student.class))).thenReturn(student);
+
+        Student result = studentService.createStudent("John", List.of(guardianId));
+        assertEquals(student, result);
+    }
+}


### PR DESCRIPTION
## Summary
- drop mandatory guardian validation when creating a student
- keep guardian-to-student mapping but store IDs only
- update service and controller to handle missing guardian IDs and adjust tests

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc55fbcd38832987948c2aee1c76f1