### PR TITLE
Add guardian listing endpoint

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
@@ -1,22 +1,34 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
 import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
+import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
 import com.xavelo.template.render.api.domain.Guardian;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
 public class GuardianController {
 
     private final CreateGuardianUseCase createGuardianUseCase;
+    private final ListGuardiansUseCase listGuardiansUseCase;
 
-    public GuardianController(CreateGuardianUseCase createGuardianUseCase) {
+    public GuardianController(CreateGuardianUseCase createGuardianUseCase, ListGuardiansUseCase listGuardiansUseCase) {
         this.createGuardianUseCase = createGuardianUseCase;
+        this.listGuardiansUseCase = listGuardiansUseCase;
+    }
+
+    @GetMapping("/guardians")
+    public ResponseEntity<List<Guardian>> listGuardians() {
+        List<Guardian> guardians = listGuardiansUseCase.listGuardians();
+        return ResponseEntity.ok(guardians);
     }
 
     @PostMapping("/guardian")

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -6,6 +6,7 @@ import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
 import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
+import com.xavelo.template.render.api.application.port.out.ListGuardiansPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.application.port.out.AssignStudentsToAuthorizationPort;
 import com.xavelo.template.render.api.domain.Authorization;
@@ -22,7 +23,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Component
-public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort, CreateGuardianPort, GetGuardianPort, AssignStudentsToAuthorizationPort {
+public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort, CreateGuardianPort, ListGuardiansPort, GetGuardianPort, AssignStudentsToAuthorizationPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
@@ -120,6 +121,15 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         com.xavelo.template.render.api.adapter.out.jdbc.Guardian saved = guardianRepository.save(entity);
 
         return new Guardian(saved.getId(), saved.getName());
+    }
+
+    @Override
+    public List<Guardian> listGuardians() {
+        logger.debug("postgress query guardian...");
+
+        return guardianRepository.findAll().stream()
+                .map(g -> new Guardian(g.getId(), g.getName()))
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/ListGuardiansUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/ListGuardiansUseCase.java
@@ -1,0 +1,9 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+import java.util.List;
+
+public interface ListGuardiansUseCase {
+    List<Guardian> listGuardians();
+}

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/ListGuardiansPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/ListGuardiansPort.java
@@ -1,0 +1,9 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+import java.util.List;
+
+public interface ListGuardiansPort {
+    List<Guardian> listGuardians();
+}

--- a/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
@@ -1,19 +1,29 @@
 package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
+import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
 import com.xavelo.template.render.api.application.port.out.CreateGuardianPort;
+import com.xavelo.template.render.api.application.port.out.ListGuardiansPort;
 import com.xavelo.template.render.api.domain.Guardian;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
-public class GuardianService implements CreateGuardianUseCase {
+public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseCase {
 
     private final CreateGuardianPort createGuardianPort;
+    private final ListGuardiansPort listGuardiansPort;
 
-    public GuardianService(CreateGuardianPort createGuardianPort) {
+    public GuardianService(CreateGuardianPort createGuardianPort, ListGuardiansPort listGuardiansPort) {
         this.createGuardianPort = createGuardianPort;
+        this.listGuardiansPort = listGuardiansPort;
+    }
+
+    @Override
+    public List<Guardian> listGuardians() {
+        return listGuardiansPort.listGuardians();
     }
 
     @Override

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianControllerTest.java
@@ -1,0 +1,41 @@
+package com.xavelo.template.render.api.adapter.in.http.secure;
+
+import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
+import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
+import com.xavelo.template.render.api.domain.Guardian;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GuardianController.class)
+class GuardianControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreateGuardianUseCase createGuardianUseCase;
+
+    @MockBean
+    private ListGuardiansUseCase listGuardiansUseCase;
+
+    @Test
+    void whenListingGuardians_thenReturnsOk() throws Exception {
+        List<Guardian> guardians = List.of(new Guardian(UUID.randomUUID(), "John"));
+        when(listGuardiansUseCase.listGuardians()).thenReturn(guardians);
+
+        mockMvc.perform(get("/api/guardians")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/xavelo/template/render/api/application/service/GuardianServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/GuardianServiceTest.java
@@ -1,0 +1,29 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.application.port.out.CreateGuardianPort;
+import com.xavelo.template.render.api.application.port.out.ListGuardiansPort;
+import com.xavelo.template.render.api.domain.Guardian;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class GuardianServiceTest {
+
+    private final CreateGuardianPort createGuardianPort = Mockito.mock(CreateGuardianPort.class);
+    private final ListGuardiansPort listGuardiansPort = Mockito.mock(ListGuardiansPort.class);
+    private final GuardianService guardianService = new GuardianService(createGuardianPort, listGuardiansPort);
+
+    @Test
+    void whenListingGuardians_thenReturnsFromPort() {
+        List<Guardian> guardians = List.of(new Guardian(UUID.randomUUID(), "John"));
+        when(listGuardiansPort.listGuardians()).thenReturn(guardians);
+
+        List<Guardian> result = guardianService.listGuardians();
+        assertEquals(guardians, result);
+    }
+}


### PR DESCRIPTION
## Summary
- expose `/api/guardians` endpoint returning all guardians
- implement listing ports, service method, and JDBC adapter support
- cover guardian listing with controller and service tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5c9f89108329854a16cb805ec332