### PR TITLE
Add listing endpoint for students

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentController.java
@@ -1,27 +1,39 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
 import com.xavelo.template.render.api.application.port.in.CreateStudentUseCase;
+import com.xavelo.template.render.api.application.port.in.ListStudentsUseCase;
 import com.xavelo.template.render.api.domain.Student;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
 public class StudentController {
 
     private final CreateStudentUseCase createStudentUseCase;
+    private final ListStudentsUseCase listStudentsUseCase;
 
-    public StudentController(CreateStudentUseCase createStudentUseCase) {
+    public StudentController(CreateStudentUseCase createStudentUseCase, ListStudentsUseCase listStudentsUseCase) {
         this.createStudentUseCase = createStudentUseCase;
+        this.listStudentsUseCase = listStudentsUseCase;
     }
 
     @PostMapping("/student")
     public ResponseEntity<Student> createStudent(@RequestBody CreateStudentRequest request) {
         Student saved = createStudentUseCase.createStudent(request.name(), request.guardianIds());
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @GetMapping("/students")
+    public ResponseEntity<List<Student>> listStudents() {
+        List<Student> students = listStudentsUseCase.listStudents();
+        return ResponseEntity.ok(students);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -6,6 +6,7 @@ import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
 import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
+import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
 import com.xavelo.template.render.api.application.port.out.AssignStudentsToAuthorizationPort;
 import com.xavelo.template.render.api.domain.Authorization;
@@ -22,7 +23,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Component
-public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort, CreateGuardianPort, GetGuardianPort, AssignStudentsToAuthorizationPort {
+public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, CreateStudentPort, ListStudentsPort, CreateGuardianPort, GetGuardianPort, AssignStudentsToAuthorizationPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
@@ -107,6 +108,17 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
                 .map(com.xavelo.template.render.api.adapter.out.jdbc.Guardian::getId)
                 .toList();
         return new Student(saved.getId(), saved.getName(), guardianIds);
+    }
+
+    @Override
+    public List<Student> listStudents() {
+        logger.debug("postgress query students...");
+        return studentRepository.findAll().stream()
+                .map(s -> new Student(s.getId(), s.getName(),
+                        s.getGuardians().stream()
+                                .map(com.xavelo.template.render.api.adapter.out.jdbc.Guardian::getId)
+                                .toList()))
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/ListStudentsUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/ListStudentsUseCase.java
@@ -1,0 +1,10 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.Student;
+
+import java.util.List;
+
+public interface ListStudentsUseCase {
+    List<Student> listStudents();
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/ListStudentsPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/ListStudentsPort.java
@@ -1,0 +1,10 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Student;
+
+import java.util.List;
+
+public interface ListStudentsPort {
+    List<Student> listStudents();
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/service/StudentService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/StudentService.java
@@ -1,7 +1,9 @@
 package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.in.CreateStudentUseCase;
+import com.xavelo.template.render.api.application.port.in.ListStudentsUseCase;
 import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
+import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.domain.Student;
 import org.springframework.stereotype.Service;
 
@@ -10,12 +12,14 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class StudentService implements CreateStudentUseCase {
+public class StudentService implements CreateStudentUseCase, ListStudentsUseCase {
 
     private final CreateStudentPort createStudentPort;
+    private final ListStudentsPort listStudentsPort;
 
-    public StudentService(CreateStudentPort createStudentPort) {
+    public StudentService(CreateStudentPort createStudentPort, ListStudentsPort listStudentsPort) {
         this.createStudentPort = createStudentPort;
+        this.listStudentsPort = listStudentsPort;
     }
 
     @Override
@@ -23,5 +27,10 @@ public class StudentService implements CreateStudentUseCase {
         List<UUID> ids = guardianIds != null ? guardianIds : Collections.emptyList();
         Student student = new Student(UUID.randomUUID(), name, ids);
         return createStudentPort.createStudent(student);
+    }
+
+    @Override
+    public List<Student> listStudents() {
+        return listStudentsPort.listStudents();
     }
 }

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentControllerTest.java
@@ -1,6 +1,7 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
 import com.xavelo.template.render.api.application.port.in.CreateStudentUseCase;
+import com.xavelo.template.render.api.application.port.in.ListStudentsUseCase;
 import com.xavelo.template.render.api.domain.Student;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -15,6 +16,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -26,6 +28,9 @@ class StudentControllerTest {
 
     @MockBean
     private CreateStudentUseCase createStudentUseCase;
+
+    @MockBean
+    private ListStudentsUseCase listStudentsUseCase;
 
     @Test
     void whenNoGuardianIds_thenReturnsCreated() throws Exception {
@@ -52,5 +57,14 @@ class StudentControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    void whenListingStudents_thenReturnsOk() throws Exception {
+        Student student = new Student(UUID.randomUUID(), "John", List.of());
+        Mockito.when(listStudentsUseCase.listStudents()).thenReturn(List.of(student));
+
+        mockMvc.perform(get("/api/students"))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## Summary
- add `ListStudentsUseCase` and port to support retrieving students
- extend student service and Postgres adapter with listing logic
- expose `GET /api/students` endpoint and tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.xavelo.template:render-api:3.3.4)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5caad1dc83298f6988694ee2c4b9