### PR TITLE
Add required email to Guardian

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,14 @@
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
                 <dependency>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateGuardianRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/CreateGuardianRequest.java
@@ -1,3 +1,5 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
-public record CreateGuardianRequest(String name) {}
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateGuardianRequest(@NotBlank String name, @NotBlank String email) {}

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
@@ -32,8 +33,8 @@ public class GuardianController {
     }
 
     @PostMapping("/guardian")
-    public ResponseEntity<Guardian> createGuardian(@RequestBody CreateGuardianRequest request) {
-        Guardian saved = createGuardianUseCase.createGuardian(request.name());
+    public ResponseEntity<Guardian> createGuardian(@Valid @RequestBody CreateGuardianRequest request) {
+        Guardian saved = createGuardianUseCase.createGuardian(request.name(), request.email());
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Guardian.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Guardian.java
@@ -18,6 +18,9 @@ public class Guardian implements Serializable {
     @Column(name = "name", length = 50, nullable = false)
     private String name;
 
+    @Column(name = "email", length = 100, nullable = false)
+    private String email;
+
     public UUID getId() {
         return id;
     }
@@ -32,5 +35,13 @@ public class Guardian implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -117,10 +117,11 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         com.xavelo.template.render.api.adapter.out.jdbc.Guardian entity =
                 new com.xavelo.template.render.api.adapter.out.jdbc.Guardian();
         entity.setName(guardian.name());
+        entity.setEmail(guardian.email());
 
         com.xavelo.template.render.api.adapter.out.jdbc.Guardian saved = guardianRepository.save(entity);
 
-        return new Guardian(saved.getId(), saved.getName());
+        return new Guardian(saved.getId(), saved.getName(), saved.getEmail());
     }
 
     @Override
@@ -128,7 +129,7 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         logger.debug("postgress query guardian...");
 
         return guardianRepository.findAll().stream()
-                .map(g -> new Guardian(g.getId(), g.getName()))
+                .map(g -> new Guardian(g.getId(), g.getName(), g.getEmail()))
                 .toList();
     }
 
@@ -151,7 +152,7 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
     @Override
     public Optional<Guardian> getGuardian(UUID id) {
         return guardianRepository.findById(id)
-                .map(g -> new Guardian(g.getId(), g.getName()));
+                .map(g -> new Guardian(g.getId(), g.getName(), g.getEmail()));
     }
 
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/CreateGuardianUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/CreateGuardianUseCase.java
@@ -3,5 +3,5 @@ package com.xavelo.template.render.api.application.port.in;
 import com.xavelo.template.render.api.domain.Guardian;
 
 public interface CreateGuardianUseCase {
-    Guardian createGuardian(String name);
+    Guardian createGuardian(String name, String email);
 }

--- a/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
@@ -8,6 +8,7 @@ import com.xavelo.template.render.api.domain.Guardian;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -27,8 +28,9 @@ public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseC
     }
 
     @Override
-    public Guardian createGuardian(String name) {
-        Guardian guardian = new Guardian(UUID.randomUUID(), name);
+    public Guardian createGuardian(String name, String email) {
+        Objects.requireNonNull(email, "email must not be null");
+        Guardian guardian = new Guardian(UUID.randomUUID(), name, email);
         return createGuardianPort.createGuardian(guardian);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/domain/Guardian.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Guardian.java
@@ -1,5 +1,10 @@
 package com.xavelo.template.render.api.domain;
 
+import java.util.Objects;
 import java.util.UUID;
 
-public record Guardian(UUID id, String name) {}
+public record Guardian(UUID id, String name, String email) {
+    public Guardian {
+        Objects.requireNonNull(email, "email must not be null");
+    }
+}

--- a/src/main/resources/db/migration/V8__add_email_to_guardian_table.sql
+++ b/src/main/resources/db/migration/V8__add_email_to_guardian_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "guardian" ADD COLUMN email VARCHAR(100) NOT NULL;

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianControllerTest.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(GuardianController.class)
@@ -31,11 +32,32 @@ class GuardianControllerTest {
 
     @Test
     void whenListingGuardians_thenReturnsOk() throws Exception {
-        List<Guardian> guardians = List.of(new Guardian(UUID.randomUUID(), "John"));
+        List<Guardian> guardians = List.of(new Guardian(UUID.randomUUID(), "John", "john@example.com"));
         when(listGuardiansUseCase.listGuardians()).thenReturn(guardians);
 
         mockMvc.perform(get("/api/guardians")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void whenCreatingGuardianWithEmail_thenReturnsCreated() throws Exception {
+        Guardian guardian = new Guardian(UUID.randomUUID(), "John", "john@example.com");
+        when(createGuardianUseCase.createGuardian("John", "john@example.com")).thenReturn(guardian);
+
+        String json = "{ \"name\": \"John\", \"email\": \"john@example.com\" }";
+        mockMvc.perform(post("/api/guardian")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void whenCreatingGuardianWithoutEmail_thenReturnsBadRequest() throws Exception {
+        String json = "{ \"name\": \"John\" }";
+        mockMvc.perform(post("/api/guardian")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/xavelo/template/render/api/application/service/GuardianServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/GuardianServiceTest.java
@@ -20,7 +20,7 @@ class GuardianServiceTest {
 
     @Test
     void whenListingGuardians_thenReturnsFromPort() {
-        List<Guardian> guardians = List.of(new Guardian(UUID.randomUUID(), "John"));
+        List<Guardian> guardians = List.of(new Guardian(UUID.randomUUID(), "John", "john@example.com"));
         when(listGuardiansPort.listGuardians()).thenReturn(guardians);
 
         List<Guardian> result = guardianService.listGuardians();


### PR DESCRIPTION
## Summary
- add email field to Guardian domain and database
- require email when creating guardians via service and controller
- validate guardian creation requests and cover with tests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5e9ee4988329800045ecd6514bea