### PR TITLE
Use in-memory database in tests

### DIFF
--- a/src/test/java/com/xavelo/template/TemplateApiRenderApplicationTests.java
+++ b/src/test/java/com/xavelo/template/TemplateApiRenderApplicationTests.java
@@ -1,26 +1,25 @@
 package com.xavelo.template;
 
 import com.xavelo.template.render.api.adapter.out.jdbc.PostgresAdapter;
+import com.xavelo.template.render.api.domain.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 class TemplateApiRenderApplicationTests {
 
-    @MockBean
+    @Autowired
     private PostgresAdapter postgresAdapter;
 
-    @Autowired
-    private ApplicationContext applicationContext;
-
     @Test
-    void contextLoads() {
-        assertNotNull(applicationContext);
+    void contextLoadsAndUsesInMemoryDb() {
+        User created = postgresAdapter.createUser(new User(null, "John"));
+        assertNotNull(created.id());
+        assertTrue(postgresAdapter.getUser(created.id()).isPresent());
     }
 
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  flyway:
+    enabled: false


### PR DESCRIPTION
## Summary
- Configure tests to use an in-memory H2 database
- Verify PostgresAdapter persists and retrieves users via in-memory DB

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc67148e648329908a22138b53a565