### PR TITLE
Fix test application context by providing dummy JWT URI

### DIFF
--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,9 +1,14 @@
 spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://localhost/jwks
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver
     username: sa
-    password: 
+    password:
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## Summary
- Provide a placeholder `spring.security.oauth2.resourceserver.jwt.jwk-set-uri` in test application configuration so Spring context can initialize during tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc693b50548329bb150c459f282fbb