### PR TITLE
Add endpoint to fetch guardian by ID with UUID validation

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianController.java
@@ -2,17 +2,20 @@ package com.xavelo.template.render.api.adapter.in.http.secure;
 
 import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
 import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
+import com.xavelo.template.render.api.application.port.in.GetGuardianUseCase;
 import com.xavelo.template.render.api.domain.Guardian;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api")
@@ -20,10 +23,12 @@ public class GuardianController {
 
     private final CreateGuardianUseCase createGuardianUseCase;
     private final ListGuardiansUseCase listGuardiansUseCase;
+    private final GetGuardianUseCase getGuardianUseCase;
 
-    public GuardianController(CreateGuardianUseCase createGuardianUseCase, ListGuardiansUseCase listGuardiansUseCase) {
+    public GuardianController(CreateGuardianUseCase createGuardianUseCase, ListGuardiansUseCase listGuardiansUseCase, GetGuardianUseCase getGuardianUseCase) {
         this.createGuardianUseCase = createGuardianUseCase;
         this.listGuardiansUseCase = listGuardiansUseCase;
+        this.getGuardianUseCase = getGuardianUseCase;
     }
 
     @GetMapping("/guardians")
@@ -36,5 +41,17 @@ public class GuardianController {
     public ResponseEntity<Guardian> createGuardian(@Valid @RequestBody CreateGuardianRequest request) {
         Guardian saved = createGuardianUseCase.createGuardian(request.name(), request.email());
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @GetMapping("/guardian/{id}")
+    public ResponseEntity<Guardian> getGuardian(@PathVariable String id) {
+        try {
+            UUID uuid = UUID.fromString(id);
+            return getGuardianUseCase.getGuardian(uuid)
+                    .map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/GetGuardianUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/GetGuardianUseCase.java
@@ -1,0 +1,10 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetGuardianUseCase {
+    Optional<Guardian> getGuardian(UUID id);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
@@ -2,24 +2,29 @@ package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
 import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
+import com.xavelo.template.render.api.application.port.in.GetGuardianUseCase;
 import com.xavelo.template.render.api.application.port.out.CreateGuardianPort;
 import com.xavelo.template.render.api.application.port.out.ListGuardiansPort;
+import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
 import com.xavelo.template.render.api.domain.Guardian;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
-public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseCase {
+public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseCase, GetGuardianUseCase {
 
     private final CreateGuardianPort createGuardianPort;
     private final ListGuardiansPort listGuardiansPort;
+    private final GetGuardianPort getGuardianPort;
 
-    public GuardianService(CreateGuardianPort createGuardianPort, ListGuardiansPort listGuardiansPort) {
+    public GuardianService(CreateGuardianPort createGuardianPort, ListGuardiansPort listGuardiansPort, GetGuardianPort getGuardianPort) {
         this.createGuardianPort = createGuardianPort;
         this.listGuardiansPort = listGuardiansPort;
+        this.getGuardianPort = getGuardianPort;
     }
 
     @Override
@@ -32,5 +37,10 @@ public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseC
         Objects.requireNonNull(email, "email must not be null");
         Guardian guardian = new Guardian(UUID.randomUUID(), name, email);
         return createGuardianPort.createGuardian(guardian);
+    }
+
+    @Override
+    public Optional<Guardian> getGuardian(UUID id) {
+        return getGuardianPort.getGuardian(id);
     }
 }


### PR DESCRIPTION
## Summary
- add GetGuardian use case and service implementation
- expose `/api/guardian/{id}` endpoint with UUID validation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ca128408329825a21bc0c0bf2fe