### PR TITLE
Add guardian assignment endpoint

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/AssignGuardiansRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/AssignGuardiansRequest.java
@@ -1,0 +1,6 @@
+package com.xavelo.template.render.api.adapter.in.http.secure;
+
+import java.util.List;
+
+public record AssignGuardiansRequest(List<String> guardianIds) {}
+

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/secure/StudentController.java
@@ -1,10 +1,12 @@
 package com.xavelo.template.render.api.adapter.in.http.secure;
 
+import com.xavelo.template.render.api.application.port.in.AssignGuardiansToStudentUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateStudentUseCase;
 import com.xavelo.template.render.api.application.port.in.ListStudentsUseCase;
 import com.xavelo.template.render.api.domain.Student;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api")
@@ -19,10 +22,14 @@ public class StudentController {
 
     private final CreateStudentUseCase createStudentUseCase;
     private final ListStudentsUseCase listStudentsUseCase;
+    private final AssignGuardiansToStudentUseCase assignGuardiansToStudentUseCase;
 
-    public StudentController(CreateStudentUseCase createStudentUseCase, ListStudentsUseCase listStudentsUseCase) {
+    public StudentController(CreateStudentUseCase createStudentUseCase,
+                             ListStudentsUseCase listStudentsUseCase,
+                             AssignGuardiansToStudentUseCase assignGuardiansToStudentUseCase) {
         this.createStudentUseCase = createStudentUseCase;
         this.listStudentsUseCase = listStudentsUseCase;
+        this.assignGuardiansToStudentUseCase = assignGuardiansToStudentUseCase;
     }
 
     @PostMapping("/student")
@@ -35,5 +42,23 @@ public class StudentController {
     public ResponseEntity<List<Student>> listStudents() {
         List<Student> students = listStudentsUseCase.listStudents();
         return ResponseEntity.ok(students);
+    }
+
+    @PostMapping("/student/{studentId}/guardians")
+    public ResponseEntity<Void> assignGuardians(@PathVariable String studentId,
+                                                @RequestBody AssignGuardiansRequest request) {
+        try {
+            if (request == null || request.guardianIds() == null || request.guardianIds().isEmpty()) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            }
+            UUID studentUuid = UUID.fromString(studentId);
+            List<UUID> guardianUuids = request.guardianIds().stream()
+                    .map(UUID::fromString)
+                    .toList();
+            assignGuardiansToStudentUseCase.assignGuardians(studentUuid, guardianUuids);
+            return ResponseEntity.status(HttpStatus.CREATED).build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -9,6 +9,7 @@ import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.application.port.out.ListGuardiansPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
+import com.xavelo.template.render.api.application.port.out.AssignGuardiansToStudentPort;
 import com.xavelo.template.render.api.application.port.out.AssignStudentsToAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.ListAuthorizationsPort;
 import com.xavelo.template.render.api.domain.Authorization;
@@ -26,7 +27,7 @@ import java.util.UUID;
 
 @Component
 public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, ListAuthorizationsPort, CreateStudentPort,
-        ListStudentsPort, CreateGuardianPort, ListGuardiansPort, GetGuardianPort, AssignStudentsToAuthorizationPort {
+        ListStudentsPort, CreateGuardianPort, ListGuardiansPort, GetGuardianPort, AssignStudentsToAuthorizationPort, AssignGuardiansToStudentPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
 
@@ -165,6 +166,20 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
             entity.setStudentId(studentId);
             authorizationStudentRepository.save(entity);
         }
+    }
+
+    @Override
+    public void assignGuardiansToStudent(UUID studentId, List<UUID> guardianIds) {
+        logger.debug("postgress update student guardians...");
+        com.xavelo.template.render.api.adapter.out.jdbc.Student student =
+                studentRepository.findById(studentId).orElse(null);
+        if (student == null) {
+            return;
+        }
+        List<com.xavelo.template.render.api.adapter.out.jdbc.Guardian> guardians =
+                guardianRepository.findAllById(guardianIds);
+        student.getGuardians().addAll(guardians);
+        studentRepository.save(student);
     }
 
     public Optional<User> getUser(UUID id) {

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/AssignGuardiansToStudentUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/AssignGuardiansToStudentUseCase.java
@@ -1,0 +1,9 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AssignGuardiansToStudentUseCase {
+    void assignGuardians(UUID studentId, List<UUID> guardianIds);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/AssignGuardiansToStudentPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/AssignGuardiansToStudentPort.java
@@ -1,0 +1,9 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AssignGuardiansToStudentPort {
+    void assignGuardiansToStudent(UUID studentId, List<UUID> guardianIds);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/service/StudentService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/StudentService.java
@@ -1,7 +1,9 @@
 package com.xavelo.template.render.api.application.service;
 
+import com.xavelo.template.render.api.application.port.in.AssignGuardiansToStudentUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateStudentUseCase;
 import com.xavelo.template.render.api.application.port.in.ListStudentsUseCase;
+import com.xavelo.template.render.api.application.port.out.AssignGuardiansToStudentPort;
 import com.xavelo.template.render.api.application.port.out.CreateStudentPort;
 import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.domain.Student;
@@ -12,14 +14,18 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class StudentService implements CreateStudentUseCase, ListStudentsUseCase {
+public class StudentService implements CreateStudentUseCase, ListStudentsUseCase, AssignGuardiansToStudentUseCase {
 
     private final CreateStudentPort createStudentPort;
     private final ListStudentsPort listStudentsPort;
+    private final AssignGuardiansToStudentPort assignGuardiansToStudentPort;
 
-    public StudentService(CreateStudentPort createStudentPort, ListStudentsPort listStudentsPort) {
+    public StudentService(CreateStudentPort createStudentPort,
+                          ListStudentsPort listStudentsPort,
+                          AssignGuardiansToStudentPort assignGuardiansToStudentPort) {
         this.createStudentPort = createStudentPort;
         this.listStudentsPort = listStudentsPort;
+        this.assignGuardiansToStudentPort = assignGuardiansToStudentPort;
     }
 
     @Override
@@ -32,5 +38,11 @@ public class StudentService implements CreateStudentUseCase, ListStudentsUseCase
     @Override
     public List<Student> listStudents() {
         return listStudentsPort.listStudents();
+    }
+
+    @Override
+    public void assignGuardians(UUID studentId, List<UUID> guardianIds) {
+        List<UUID> ids = guardianIds != null ? guardianIds : Collections.emptyList();
+        assignGuardiansToStudentPort.assignGuardiansToStudent(studentId, ids);
     }
 }


### PR DESCRIPTION
## Summary
- add endpoint to assign guardians to a student
- validate UUID format for student and guardian IDs
- implement backing service and persistence logic

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6da727e0832987744ee079e887dd