### PR TITLE
Ensure transactional student-guardian assignments

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -19,6 +19,7 @@ import com.xavelo.template.render.api.domain.Guardian;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
@@ -169,6 +170,7 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
     }
 
     @Override
+    @Transactional
     public void assignGuardiansToStudent(UUID studentId, List<UUID> guardianIds) {
         logger.debug("postgress update student guardians...");
         com.xavelo.template.render.api.adapter.out.jdbc.Student student =

--- a/src/test/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapterIntegrationTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapterIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.xavelo.template.render.api.adapter.out.jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class PostgresAdapterIntegrationTest {
+
+    @Autowired
+    private PostgresAdapter postgresAdapter;
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+    @Autowired
+    private GuardianRepository guardianRepository;
+
+    @Test
+    void assignGuardiansToStudent_persistsGuardians() {
+        Guardian guardian = new Guardian();
+        guardian.setName("Guardian");
+        guardian.setEmail("g@example.com");
+        guardian = guardianRepository.save(guardian);
+
+        Student student = new Student();
+        student.setName("Student");
+        student = studentRepository.save(student);
+
+        postgresAdapter.assignGuardiansToStudent(student.getId(), List.of(guardian.getId()));
+
+        Student updated = studentRepository.findAll()
+                .stream()
+                .filter(s -> s.getId().equals(student.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(updated.getGuardians()).hasSize(1);
+        assertThat(updated.getGuardians().iterator().next().getId())
+                .isEqualTo(guardian.getId());
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap guardian assignment in a transactional boundary to avoid lazy initialization errors
- Add integration test to verify guardians are persisted to students

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7366eddc8329a568b48f4a1942b5