### PR TITLE
Expose student list on authorization retrieval

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
@@ -2,6 +2,7 @@ package com.xavelo.template.render.api.adapter.in.http.authorization;
 
 import com.xavelo.template.render.api.application.port.in.AssignStudentsToAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
+import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
 import com.xavelo.template.render.api.domain.Authorization;
@@ -29,13 +30,16 @@ public class AuthorizationController {
     private final CreateAuthorizationUseCase createAuthorizationUseCase;
     private final AssignStudentsToAuthorizationUseCase assignStudentsToAuthorizationUseCase;
     private final ListAuthorizationsUseCase listAuthorizationsUseCase;
+    private final GetAuthorizationUseCase getAuthorizationUseCase;
 
     public AuthorizationController(CreateAuthorizationUseCase createAuthorizationUseCase,
                                    AssignStudentsToAuthorizationUseCase assignStudentsToAuthorizationUseCase,
-                                   ListAuthorizationsUseCase listAuthorizationsUseCase) {
+                                   ListAuthorizationsUseCase listAuthorizationsUseCase,
+                                   GetAuthorizationUseCase getAuthorizationUseCase) {
         this.createAuthorizationUseCase = createAuthorizationUseCase;
         this.assignStudentsToAuthorizationUseCase = assignStudentsToAuthorizationUseCase;
         this.listAuthorizationsUseCase = listAuthorizationsUseCase;
+        this.getAuthorizationUseCase = getAuthorizationUseCase;
     }
 
     @PostMapping("/authorization")
@@ -82,5 +86,12 @@ public class AuthorizationController {
     public ResponseEntity<List<Authorization>> listAuthorizations() {
         List<Authorization> authorizations = listAuthorizationsUseCase.listAuthorizations();
         return ResponseEntity.ok(authorizations);
+    }
+
+    @GetMapping("/authorization/{authorizationId}")
+    public ResponseEntity<Authorization> getAuthorization(@PathVariable UUID authorizationId) {
+        return getAuthorizationUseCase.getAuthorization(authorizationId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/AuthorizationStudentRepository.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/AuthorizationStudentRepository.java
@@ -4,8 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
+import java.util.List;
 
 @Repository
 public interface AuthorizationStudentRepository extends JpaRepository<AuthorizationStudent, UUID> {
+    List<AuthorizationStudent> findByAuthorizationId(UUID authorizationId);
 }
 

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/GetAuthorizationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/GetAuthorizationUseCase.java
@@ -1,0 +1,10 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.Authorization;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetAuthorizationUseCase {
+    Optional<Authorization> getAuthorization(UUID authorizationId);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/GetAuthorizationPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/GetAuthorizationPort.java
@@ -1,0 +1,10 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Authorization;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetAuthorizationPort {
+    Optional<Authorization> getAuthorization(UUID authorizationId);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -2,9 +2,11 @@ package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.in.AssignStudentsToAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
+import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
-import com.xavelo.template.render.api.application.port.out.CreateAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.AssignStudentsToAuthorizationPort;
+import com.xavelo.template.render.api.application.port.out.CreateAuthorizationPort;
+import com.xavelo.template.render.api.application.port.out.GetAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListAuthorizationsPort;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
@@ -12,23 +14,28 @@ import com.xavelo.template.render.api.domain.Authorization;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
-public class AuthorizationService implements CreateAuthorizationUseCase, AssignStudentsToAuthorizationUseCase, ListAuthorizationsUseCase {
+public class AuthorizationService implements CreateAuthorizationUseCase, AssignStudentsToAuthorizationUseCase,
+        ListAuthorizationsUseCase, GetAuthorizationUseCase {
 
     private final CreateAuthorizationPort createAuthorizationPort;
     private final AssignStudentsToAuthorizationPort assignStudentsToAuthorizationPort;
     private final ListAuthorizationsPort listAuthorizationsPort;
+    private final GetAuthorizationPort getAuthorizationPort;
     private final GetUserPort getUserPort;
 
     public AuthorizationService(CreateAuthorizationPort createAuthorizationPort,
                                 AssignStudentsToAuthorizationPort assignStudentsToAuthorizationPort,
                                 ListAuthorizationsPort listAuthorizationsPort,
+                                GetAuthorizationPort getAuthorizationPort,
                                 GetUserPort getUserPort) {
         this.createAuthorizationPort = createAuthorizationPort;
         this.assignStudentsToAuthorizationPort = assignStudentsToAuthorizationPort;
         this.listAuthorizationsPort = listAuthorizationsPort;
+        this.getAuthorizationPort = getAuthorizationPort;
         this.getUserPort = getUserPort;
     }
 
@@ -39,7 +46,8 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
             throw new UserNotFoundException(createdByUuid);
         }
 
-        Authorization authorization = new Authorization(UUID.randomUUID(), title, text, status, null, createdBy, null, sentBy, null, approvedBy);
+        Authorization authorization = new Authorization(UUID.randomUUID(), title, text, status, null, createdBy, null, sentBy,
+                null, approvedBy, List.of());
         return createAuthorizationPort.createAuthorization(authorization);
     }
 
@@ -51,5 +59,10 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     @Override
     public List<Authorization> listAuthorizations() {
         return listAuthorizationsPort.listAuthorizations();
+    }
+
+    @Override
+    public Optional<Authorization> getAuthorization(UUID authorizationId) {
+        return getAuthorizationPort.getAuthorization(authorizationId);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
@@ -1,6 +1,7 @@
 package com.xavelo.template.render.api.domain;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public record Authorization(
@@ -13,5 +14,6 @@ public record Authorization(
         Instant sentAt,
         String sentBy,
         Instant approvedAt,
-        String approvedBy
+        String approvedBy,
+        List<UUID> studentIds
 ) {}

--- a/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
@@ -2,6 +2,7 @@ package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.out.AssignStudentsToAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.CreateAuthorizationPort;
+import com.xavelo.template.render.api.application.port.out.GetAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListAuthorizationsPort;
 import com.xavelo.template.render.api.domain.Authorization;
@@ -29,13 +30,16 @@ class AuthorizationServiceTest {
     private ListAuthorizationsPort listAuthorizationsPort;
     @Mock
     private GetUserPort getUserPort;
+    @Mock
+    private GetAuthorizationPort getAuthorizationPort;
 
     private AuthorizationService authorizationService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        authorizationService = new AuthorizationService(createAuthorizationPort, assignStudentsToAuthorizationPort, listAuthorizationsPort, getUserPort);
+        authorizationService = new AuthorizationService(createAuthorizationPort, assignStudentsToAuthorizationPort,
+                listAuthorizationsPort, getAuthorizationPort, getUserPort);
     }
 
     @Test
@@ -51,7 +55,7 @@ class AuthorizationServiceTest {
     void whenCreatedByUserExists_thenCreatesAuthorization() {
         String createdBy = UUID.randomUUID().toString();
         Mockito.when(getUserPort.getUser(UUID.fromString(createdBy))).thenReturn(Optional.of(new User(UUID.fromString(createdBy), "name")));
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", null, createdBy, null, null, null, null);
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", null, createdBy, null, null, null, null, java.util.List.of());
         Mockito.when(createAuthorizationPort.createAuthorization(Mockito.any())).thenReturn(authorization);
 
         Authorization result = authorizationService.createAuthorization("Title", "Text", "draft", createdBy, null, null);


### PR DESCRIPTION
## Summary
- Extend authorization domain with studentIds list
- Implement GetAuthorization use case and endpoint to fetch single authorization with students
- Update persistence adapter and tests for student mapping

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc815275908329b58a081b12d35456