### PR TITLE
feat: add email adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
         <!-- OpenAPI documentation -->
         <dependency>
                 <groupId>org.springdoc</groupId>

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/email/EmailAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/email/EmailAdapter.java
@@ -1,0 +1,30 @@
+package com.xavelo.template.render.api.adapter.out.email;
+
+import com.xavelo.template.render.api.application.port.out.SendEmailPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailAdapter implements SendEmailPort {
+    private static final Logger logger = LoggerFactory.getLogger(EmailAdapter.class);
+    private final JavaMailSender mailSender;
+
+    public EmailAdapter(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void sendEmail(String from, String to, String subject, String content) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(from);
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(content);
+        mailSender.send(message);
+        logger.info("Sent email from {} to {} with subject '{}'", from, to, subject);
+    }
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/SendEmailPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/SendEmailPort.java
@@ -1,0 +1,5 @@
+package com.xavelo.template.render.api.application.port.out;
+
+public interface SendEmailPort {
+    void sendEmail(String from, String to, String subject, String content);
+}


### PR DESCRIPTION
## Summary
- add spring mail starter dependency
- implement EmailAdapter to send messages via JavaMailSender

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc86c4ea088329a3196860c596f066