### PR TITLE
Add test mail configuration and make EmailAdapter conditional

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/out/email/EmailAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/email/EmailAdapter.java
@@ -3,11 +3,13 @@ package com.xavelo.template.render.api.adapter.out.email;
 import com.xavelo.template.render.api.application.port.out.SendEmailPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnBean(JavaMailSender.class)
 public class EmailAdapter implements SendEmailPort {
     private static final Logger logger = LoggerFactory.getLogger(EmailAdapter.class);
     private final JavaMailSender mailSender;

--- a/src/test/java/com/xavelo/template/TemplateApiRenderApplicationTests.java
+++ b/src/test/java/com/xavelo/template/TemplateApiRenderApplicationTests.java
@@ -5,11 +5,15 @@ import com.xavelo.template.render.api.domain.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import com.xavelo.template.TestMailConfig;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
+@Import(TestMailConfig.class)
 class TemplateApiRenderApplicationTests {
 
     @Autowired

--- a/src/test/java/com/xavelo/template/TestMailConfig.java
+++ b/src/test/java/com/xavelo/template/TestMailConfig.java
@@ -1,0 +1,15 @@
+package com.xavelo.template;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@TestConfiguration
+public class TestMailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return Mockito.mock(JavaMailSender.class);
+    }
+}

--- a/src/test/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapterIntegrationTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapterIntegrationTest.java
@@ -3,12 +3,16 @@ package com.xavelo.template.render.api.adapter.out.jdbc;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import com.xavelo.template.TestMailConfig;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(TestMailConfig.class)
 class PostgresAdapterIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- add `TestMailConfig` providing a mock `JavaMailSender`
- import `TestMailConfig` in Spring Boot integration tests
- guard `EmailAdapter` creation with `@ConditionalOnBean(JavaMailSender.class)`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc897c37ac83298d6d81520603f2b9