### PR TITLE
Add authorization notification tracking

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/RespondNotificationRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/RespondNotificationRequest.java
@@ -1,0 +1,3 @@
+package com.xavelo.template.render.api.adapter.in.http.authorization;
+
+public record RespondNotificationRequest(String status, String respondedBy) {}

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Notification.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Notification.java
@@ -1,0 +1,63 @@
+package com.xavelo.template.render.api.adapter.out.jdbc;
+
+import jakarta.persistence.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "\"notification\"")
+public class Notification implements Serializable {
+
+    @Id
+    @GeneratedValue
+    @org.hibernate.annotations.UuidGenerator
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "authorization_id", nullable = false)
+    private UUID authorizationId;
+
+    @Column(name = "student_id", nullable = false)
+    private UUID studentId;
+
+    @Column(name = "guardian_id", nullable = false)
+    private UUID guardianId;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    @Column(name = "responded_at")
+    private Instant respondedAt;
+
+    @Column(name = "responded_by")
+    private String respondedBy;
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+
+    public UUID getAuthorizationId() { return authorizationId; }
+    public void setAuthorizationId(UUID authorizationId) { this.authorizationId = authorizationId; }
+
+    public UUID getStudentId() { return studentId; }
+    public void setStudentId(UUID studentId) { this.studentId = studentId; }
+
+    public UUID getGuardianId() { return guardianId; }
+    public void setGuardianId(UUID guardianId) { this.guardianId = guardianId; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public Instant getSentAt() { return sentAt; }
+    public void setSentAt(Instant sentAt) { this.sentAt = sentAt; }
+
+    public Instant getRespondedAt() { return respondedAt; }
+    public void setRespondedAt(Instant respondedAt) { this.respondedAt = respondedAt; }
+
+    public String getRespondedBy() { return respondedBy; }
+    public void setRespondedBy(String respondedBy) { this.respondedBy = respondedBy; }
+}

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/NotificationRepository.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.xavelo.template.render.api.adapter.out.jdbc;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+    List<Notification> findByAuthorizationId(UUID authorizationId);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/NotificationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/NotificationUseCase.java
@@ -1,0 +1,12 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.Notification;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificationUseCase {
+    List<Notification> listNotifications(UUID authorizationId);
+    void markNotificationSent(UUID notificationId);
+    void respondToNotification(UUID notificationId, String status, String respondedBy);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/SendNotificationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/SendNotificationUseCase.java
@@ -1,0 +1,7 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import java.util.UUID;
+
+public interface SendNotificationUseCase {
+    void sendNotification(UUID authorizationId, UUID studentId, UUID guardianId);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationEmailPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationEmailPort.java
@@ -1,0 +1,7 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Notification;
+
+public interface NotificationEmailPort {
+    void sendNotificationEmail(Notification notification);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
@@ -1,0 +1,14 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Notification;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificationPort {
+    void createNotification(Notification notification);
+    List<Notification> listNotifications(UUID authorizationId);
+    void markNotificationSent(UUID notificationId, Instant sentAt);
+    void respondToNotification(UUID notificationId, String status, Instant respondedAt, String respondedBy);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -1,42 +1,58 @@
 package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.in.AssignStudentsToAuthorizationUseCase;
+import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
+import com.xavelo.template.render.api.application.port.in.SendNotificationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
 import com.xavelo.template.render.api.application.port.out.AssignStudentsToAuthorizationPort;
+import com.xavelo.template.render.api.application.port.out.NotificationPort;
 import com.xavelo.template.render.api.application.port.out.CreateAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.GetAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
 import com.xavelo.template.render.api.application.port.out.ListAuthorizationsPort;
+import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
 import com.xavelo.template.render.api.domain.Authorization;
+import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.Student;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Service
 public class AuthorizationService implements CreateAuthorizationUseCase, AssignStudentsToAuthorizationUseCase,
-        ListAuthorizationsUseCase, GetAuthorizationUseCase {
+        ListAuthorizationsUseCase, GetAuthorizationUseCase, NotificationUseCase {
 
     private final CreateAuthorizationPort createAuthorizationPort;
     private final AssignStudentsToAuthorizationPort assignStudentsToAuthorizationPort;
     private final ListAuthorizationsPort listAuthorizationsPort;
     private final GetAuthorizationPort getAuthorizationPort;
     private final GetUserPort getUserPort;
+    private final ListStudentsPort listStudentsPort;
+    private final NotificationPort notificationPort;
+    private final SendNotificationUseCase sendNotificationUseCase;
 
     public AuthorizationService(CreateAuthorizationPort createAuthorizationPort,
                                 AssignStudentsToAuthorizationPort assignStudentsToAuthorizationPort,
                                 ListAuthorizationsPort listAuthorizationsPort,
                                 GetAuthorizationPort getAuthorizationPort,
-                                GetUserPort getUserPort) {
+                                GetUserPort getUserPort,
+                                ListStudentsPort listStudentsPort,
+                                NotificationPort notificationPort,
+                                SendNotificationUseCase sendNotificationUseCase) {
         this.createAuthorizationPort = createAuthorizationPort;
         this.assignStudentsToAuthorizationPort = assignStudentsToAuthorizationPort;
         this.listAuthorizationsPort = listAuthorizationsPort;
         this.getAuthorizationPort = getAuthorizationPort;
         this.getUserPort = getUserPort;
+        this.listStudentsPort = listStudentsPort;
+        this.notificationPort = notificationPort;
+        this.sendNotificationUseCase = sendNotificationUseCase;
     }
 
     @Override
@@ -54,6 +70,16 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     @Override
     public void assignStudents(UUID authorizationId, java.util.List<UUID> studentIds) {
         assignStudentsToAuthorizationPort.assignStudentsToAuthorization(authorizationId, studentIds);
+        List<Student> students = listStudentsPort.listStudents();
+        for (UUID studentId : studentIds) {
+            students.stream().filter(s -> s.id().equals(studentId)).findFirst().ifPresent(student -> {
+                if (student.guardianIds() != null) {
+                    for (UUID guardianId : student.guardianIds()) {
+                        sendNotificationUseCase.sendNotification(authorizationId, studentId, guardianId);
+                    }
+                }
+            });
+        }
     }
 
     @Override
@@ -64,5 +90,20 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     @Override
     public Optional<Authorization> getAuthorization(UUID authorizationId) {
         return getAuthorizationPort.getAuthorization(authorizationId);
+    }
+
+    @Override
+    public List<Notification> listNotifications(UUID authorizationId) {
+        return notificationPort.listNotifications(authorizationId);
+    }
+
+    @Override
+    public void markNotificationSent(UUID notificationId) {
+        notificationPort.markNotificationSent(notificationId, Instant.now());
+    }
+
+    @Override
+    public void respondToNotification(UUID notificationId, String status, String respondedBy) {
+        notificationPort.respondToNotification(notificationId, status, Instant.now(), respondedBy);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/application/service/NotificationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/NotificationService.java
@@ -1,0 +1,38 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.application.port.in.SendNotificationUseCase;
+import com.xavelo.template.render.api.application.port.out.NotificationPort;
+import com.xavelo.template.render.api.application.port.out.NotificationEmailPort;
+import com.xavelo.template.render.api.domain.Notification;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+public class NotificationService implements SendNotificationUseCase {
+
+    private final NotificationPort notificationPort;
+    private final NotificationEmailPort notificationEmailPort;
+
+    public NotificationService(NotificationPort notificationPort, NotificationEmailPort notificationEmailPort) {
+        this.notificationPort = notificationPort;
+        this.notificationEmailPort = notificationEmailPort;
+    }
+
+    @Override
+    public void sendNotification(UUID authorizationId, UUID studentId, UUID guardianId) {
+        Notification notification = new Notification(
+                UUID.randomUUID(),
+                authorizationId,
+                studentId,
+                guardianId,
+                "SENT",
+                Instant.now(),
+                null,
+                null
+        );
+        notificationPort.createNotification(notification);
+        notificationEmailPort.sendNotificationEmail(notification);
+    }
+}

--- a/src/main/java/com/xavelo/template/render/api/domain/Notification.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Notification.java
@@ -1,0 +1,15 @@
+package com.xavelo.template.render.api.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record Notification(
+        UUID id,
+        UUID authorizationId,
+        UUID studentId,
+        UUID guardianId,
+        String status,
+        Instant sentAt,
+        Instant respondedAt,
+        String respondedBy
+) {}

--- a/src/main/resources/db/migration/V9__create_notification_table.sql
+++ b/src/main/resources/db/migration/V9__create_notification_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "notification" (
+    id UUID PRIMARY KEY,
+    authorization_id UUID NOT NULL,
+    student_id UUID NOT NULL,
+    guardian_id UUID NOT NULL,
+    status VARCHAR NOT NULL,
+    sent_at TIMESTAMPTZ,
+    responded_at TIMESTAMPTZ,
+    responded_by VARCHAR
+);

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationControllerTest.java
@@ -1,0 +1,76 @@
+package com.xavelo.template.render.api.adapter.in.http.authorization;
+
+import com.xavelo.template.render.api.application.port.in.AssignStudentsToAuthorizationUseCase;
+import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
+import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
+import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
+import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
+import com.xavelo.template.render.api.domain.Notification;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthorizationController.class)
+class AuthorizationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreateAuthorizationUseCase createAuthorizationUseCase;
+
+    @MockBean
+    private AssignStudentsToAuthorizationUseCase assignStudentsToAuthorizationUseCase;
+
+    @MockBean
+    private ListAuthorizationsUseCase listAuthorizationsUseCase;
+
+    @MockBean
+    private GetAuthorizationUseCase getAuthorizationUseCase;
+
+    @MockBean
+    private NotificationUseCase notificationUseCase;
+
+    @Test
+    void whenListingNotifications_thenReturnsOk() throws Exception {
+        UUID authorizationId = UUID.randomUUID();
+        Notification notification = new Notification(UUID.randomUUID(), authorizationId,
+                UUID.randomUUID(), UUID.randomUUID(), "PENDING", null, null, null);
+        Mockito.when(notificationUseCase.listNotifications(authorizationId)).thenReturn(List.of(notification));
+
+        mockMvc.perform(get("/api/authorization/" + authorizationId + "/notifications"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(notification.id().toString()));
+    }
+
+    @Test
+    void whenMarkingNotificationSent_thenReturnsOk() throws Exception {
+        UUID notificationId = UUID.randomUUID();
+        mockMvc.perform(post("/api/notification/" + notificationId + "/sent"))
+                .andExpect(status().isOk());
+        Mockito.verify(notificationUseCase).markNotificationSent(notificationId);
+    }
+
+    @Test
+    void whenRespondingToNotification_thenReturnsOk() throws Exception {
+        UUID notificationId = UUID.randomUUID();
+        String json = "{\"status\":\"APPROVED\",\"respondedBy\":\"guardian\"}";
+        mockMvc.perform(post("/api/notification/" + notificationId + "/response")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk());
+        Mockito.verify(notificationUseCase).respondToNotification(notificationId, "APPROVED", "guardian");
+    }
+}

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
@@ -2,6 +2,7 @@ package com.xavelo.template.render.api.adapter.in.http.secure;
 
 import com.xavelo.template.render.api.adapter.in.http.authorization.AuthorizationController;
 import com.xavelo.template.render.api.application.port.in.AssignStudentsToAuthorizationUseCase;
+import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
@@ -42,6 +43,9 @@ class AuthorizationControllerTest {
 
     @MockBean
     private GetAuthorizationUseCase getAuthorizationUseCase;
+
+    @MockBean
+    private NotificationUseCase notificationUseCase;
 
     @Test
     void whenMissingRequiredField_thenReturnsBadRequest() throws Exception {

--- a/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceTest.java
@@ -1,0 +1,45 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.application.port.out.NotificationPort;
+import com.xavelo.template.render.api.application.port.out.NotificationEmailPort;
+import com.xavelo.template.render.api.domain.Notification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationPort notificationPort;
+    @Mock
+    private NotificationEmailPort notificationEmailPort;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        notificationService = new NotificationService(notificationPort, notificationEmailPort);
+    }
+
+    @Test
+    void whenSendingNotification_thenPersistsAndSendsEmail() {
+        UUID authorizationId = UUID.randomUUID();
+        UUID studentId = UUID.randomUUID();
+        UUID guardianId = UUID.randomUUID();
+
+        notificationService.sendNotification(authorizationId, studentId, guardianId);
+
+        Mockito.verify(notificationPort).createNotification(ArgumentMatchers.argThat(n ->
+                n.authorizationId().equals(authorizationId) &&
+                        n.studentId().equals(studentId) &&
+                        n.guardianId().equals(guardianId) &&
+                        n.status().equals("SENT")));
+        Mockito.verify(notificationEmailPort).sendNotificationEmail(ArgumentMatchers.any(Notification.class));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce SendNotificationUseCase and NotificationEmailPort for dispatching notification emails while recording them
- delegate student assignment notification creation to SendNotificationUseCase
- cover notification sending with dedicated unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc868cea4c83298b0dbfeec94d127c