### PR TITLE
Add notification status enum and database table

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/RespondNotificationRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/RespondNotificationRequest.java
@@ -1,3 +1,5 @@
 package com.xavelo.template.render.api.adapter.in.http.authorization;
 
-public record RespondNotificationRequest(String status, String respondedBy) {}
+import com.xavelo.template.render.api.domain.NotificationStatus;
+
+public record RespondNotificationRequest(NotificationStatus status, String respondedBy) {}

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Notification.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Notification.java
@@ -6,6 +6,8 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
 
+import com.xavelo.template.render.api.domain.NotificationStatus;
+
 @Entity
 @Table(name = "\"notification\"")
 public class Notification implements Serializable {
@@ -25,8 +27,9 @@ public class Notification implements Serializable {
     @Column(name = "guardian_id", nullable = false)
     private UUID guardianId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private String status;
+    private NotificationStatus status;
 
     @Column(name = "sent_at")
     private Instant sentAt;
@@ -49,8 +52,8 @@ public class Notification implements Serializable {
     public UUID getGuardianId() { return guardianId; }
     public void setGuardianId(UUID guardianId) { this.guardianId = guardianId; }
 
-    public String getStatus() { return status; }
-    public void setStatus(String status) { this.status = status; }
+    public NotificationStatus getStatus() { return status; }
+    public void setStatus(NotificationStatus status) { this.status = status; }
 
     public Instant getSentAt() { return sentAt; }
     public void setSentAt(Instant sentAt) { this.sentAt = sentAt; }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -16,6 +16,7 @@ import com.xavelo.template.render.api.application.port.out.NotificationPort;
 import com.xavelo.template.render.api.application.port.out.ListAuthorizationsPort;
 import com.xavelo.template.render.api.domain.Authorization;
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 import com.xavelo.template.render.api.domain.Student;
 import com.xavelo.template.render.api.domain.User;
 import com.xavelo.template.render.api.domain.Guardian;
@@ -241,14 +242,14 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
     @Override
     public void markNotificationSent(UUID notificationId, Instant sentAt) {
         notificationRepository.findById(notificationId).ifPresent(n -> {
-            n.setStatus("SENT");
+            n.setStatus(NotificationStatus.SENT);
             n.setSentAt(sentAt);
             notificationRepository.save(n);
         });
     }
 
     @Override
-    public void respondToNotification(UUID notificationId, String status, Instant respondedAt, String respondedBy) {
+    public void respondToNotification(UUID notificationId, NotificationStatus status, Instant respondedAt, String respondedBy) {
         notificationRepository.findById(notificationId).ifPresent(n -> {
             n.setStatus(status);
             n.setRespondedAt(respondedAt);

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/NotificationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/NotificationUseCase.java
@@ -1,6 +1,7 @@
 package com.xavelo.template.render.api.application.port.in;
 
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,5 +9,5 @@ import java.util.UUID;
 public interface NotificationUseCase {
     List<Notification> listNotifications(UUID authorizationId);
     void markNotificationSent(UUID notificationId);
-    void respondToNotification(UUID notificationId, String status, String respondedBy);
+    void respondToNotification(UUID notificationId, NotificationStatus status, String respondedBy);
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
@@ -1,6 +1,7 @@
 package com.xavelo.template.render.api.application.port.out;
 
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 
 import java.time.Instant;
 import java.util.List;
@@ -10,5 +11,5 @@ public interface NotificationPort {
     void createNotification(Notification notification);
     List<Notification> listNotifications(UUID authorizationId);
     void markNotificationSent(UUID notificationId, Instant sentAt);
-    void respondToNotification(UUID notificationId, String status, Instant respondedAt, String respondedBy);
+    void respondToNotification(UUID notificationId, NotificationStatus status, Instant respondedAt, String respondedBy);
 }

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -16,6 +16,7 @@ import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
 import com.xavelo.template.render.api.domain.Authorization;
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 import com.xavelo.template.render.api.domain.Student;
 import org.springframework.stereotype.Service;
 
@@ -103,7 +104,7 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     }
 
     @Override
-    public void respondToNotification(UUID notificationId, String status, String respondedBy) {
+    public void respondToNotification(UUID notificationId, NotificationStatus status, String respondedBy) {
         notificationPort.respondToNotification(notificationId, status, Instant.now(), respondedBy);
     }
 }

--- a/src/main/java/com/xavelo/template/render/api/application/service/NotificationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.xavelo.template.render.api.application.port.in.SendNotificationUseCas
 import com.xavelo.template.render.api.application.port.out.NotificationPort;
 import com.xavelo.template.render.api.application.port.out.NotificationEmailPort;
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -27,7 +28,7 @@ public class NotificationService implements SendNotificationUseCase {
                 authorizationId,
                 studentId,
                 guardianId,
-                "SENT",
+                NotificationStatus.SENT,
                 Instant.now(),
                 null,
                 null

--- a/src/main/java/com/xavelo/template/render/api/domain/Notification.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Notification.java
@@ -8,7 +8,7 @@ public record Notification(
         UUID authorizationId,
         UUID studentId,
         UUID guardianId,
-        String status,
+        NotificationStatus status,
         Instant sentAt,
         Instant respondedAt,
         String respondedBy

--- a/src/main/java/com/xavelo/template/render/api/domain/NotificationStatus.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/NotificationStatus.java
@@ -1,0 +1,8 @@
+package com.xavelo.template.render.api.domain;
+
+public enum NotificationStatus {
+    SENT,
+    APPROVED,
+    REJECT,
+    EXPIRE
+}

--- a/src/main/resources/db/migration/V10__create_notification_status_table.sql
+++ b/src/main/resources/db/migration/V10__create_notification_status_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "notification_status" (
+    code VARCHAR PRIMARY KEY
+);
+
+INSERT INTO "notification_status" (code) VALUES
+    ('SENT'),
+    ('APPROVED'),
+    ('REJECT'),
+    ('EXPIRE');
+
+ALTER TABLE "notification"
+    ADD CONSTRAINT fk_notification_status
+    FOREIGN KEY (status) REFERENCES "notification_status"(code);

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationControllerTest.java
@@ -6,6 +6,7 @@ import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUse
 import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +48,7 @@ class AuthorizationControllerTest {
     void whenListingNotifications_thenReturnsOk() throws Exception {
         UUID authorizationId = UUID.randomUUID();
         Notification notification = new Notification(UUID.randomUUID(), authorizationId,
-                UUID.randomUUID(), UUID.randomUUID(), "PENDING", null, null, null);
+                UUID.randomUUID(), UUID.randomUUID(), NotificationStatus.SENT, null, null, null);
         Mockito.when(notificationUseCase.listNotifications(authorizationId)).thenReturn(List.of(notification));
 
         mockMvc.perform(get("/api/authorization/" + authorizationId + "/notifications"))
@@ -71,6 +72,6 @@ class AuthorizationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
                 .andExpect(status().isOk());
-        Mockito.verify(notificationUseCase).respondToNotification(notificationId, "APPROVED", "guardian");
+        Mockito.verify(notificationUseCase).respondToNotification(notificationId, NotificationStatus.APPROVED, "guardian");
     }
 }

--- a/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
@@ -10,6 +10,7 @@ import com.xavelo.template.render.api.application.port.out.ListAuthorizationsPor
 import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.domain.Authorization;
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 import com.xavelo.template.render.api.domain.Student;
 import com.xavelo.template.render.api.domain.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,7 +98,7 @@ class AuthorizationServiceTest {
     @Test
     void whenRespondingToNotification_thenCallsPort() {
         UUID notificationId = UUID.randomUUID();
-        authorizationService.respondToNotification(notificationId, "APPROVED", "guardian");
-        Mockito.verify(notificationPort).respondToNotification(Mockito.eq(notificationId), Mockito.eq("APPROVED"), Mockito.any(), Mockito.eq("guardian"));
+        authorizationService.respondToNotification(notificationId, NotificationStatus.APPROVED, "guardian");
+        Mockito.verify(notificationPort).respondToNotification(Mockito.eq(notificationId), Mockito.eq(NotificationStatus.APPROVED), Mockito.any(), Mockito.eq("guardian"));
     }
 }

--- a/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceTest.java
@@ -3,6 +3,7 @@ package com.xavelo.template.render.api.application.service;
 import com.xavelo.template.render.api.application.port.out.NotificationPort;
 import com.xavelo.template.render.api.application.port.out.NotificationEmailPort;
 import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -39,7 +40,7 @@ class NotificationServiceTest {
                 n.authorizationId().equals(authorizationId) &&
                         n.studentId().equals(studentId) &&
                         n.guardianId().equals(guardianId) &&
-                        n.status().equals("SENT")));
+                        n.status() == NotificationStatus.SENT));
         Mockito.verify(notificationEmailPort).sendNotificationEmail(ArgumentMatchers.any(Notification.class));
     }
 }


### PR DESCRIPTION
## Summary
- add `notification_status` table with allowed values
- introduce `NotificationStatus` enum and use throughout notification handling
- enforce statuses when sending or responding to notifications

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc90f2960883298c6b3ad2e351198d