### PR TITLE
feat: add notification email adapter

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/out/email/NotificationEmailAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/email/NotificationEmailAdapter.java
@@ -1,0 +1,46 @@
+package com.xavelo.template.render.api.adapter.out.email;
+
+import com.xavelo.template.render.api.application.port.out.NotificationEmailPort;
+import com.xavelo.template.render.api.application.port.out.SendEmailPort;
+import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
+import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.Guardian;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@ConditionalOnBean(SendEmailPort.class)
+@ConditionalOnMissingBean(NotificationEmailPort.class)
+public class NotificationEmailAdapter implements NotificationEmailPort {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationEmailAdapter.class);
+
+    private final SendEmailPort sendEmailPort;
+    private final GetGuardianPort getGuardianPort;
+
+    public NotificationEmailAdapter(SendEmailPort sendEmailPort, GetGuardianPort getGuardianPort) {
+        this.sendEmailPort = sendEmailPort;
+        this.getGuardianPort = getGuardianPort;
+    }
+
+    @Override
+    public void sendNotificationEmail(Notification notification) {
+        Optional<Guardian> guardian = getGuardianPort.getGuardian(notification.guardianId());
+        if (guardian.isEmpty()) {
+            logger.warn("Guardian with id {} not found. Email not sent.", notification.guardianId());
+            return;
+        }
+
+        String to = guardian.get().email();
+        String subject = "Authorization Notification";
+        String content = "You have a new notification for authorization " + notification.authorizationId();
+        sendEmailPort.sendEmail("no-reply@example.com", to, subject, content);
+        logger.info("Sent notification email to {} for authorization {}", to, notification.authorizationId());
+    }
+}
+

--- a/src/test/java/com/xavelo/template/render/api/adapter/out/email/NotificationEmailAdapterTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/out/email/NotificationEmailAdapterTest.java
@@ -1,0 +1,69 @@
+package com.xavelo.template.render.api.adapter.out.email;
+
+import com.xavelo.template.render.api.application.port.out.NotificationEmailPort;
+import com.xavelo.template.render.api.application.port.out.SendEmailPort;
+import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
+import com.xavelo.template.render.api.domain.Guardian;
+import com.xavelo.template.render.api.domain.Notification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationEmailAdapterTest {
+
+    @Mock
+    private SendEmailPort sendEmailPort;
+
+    @Mock
+    private GetGuardianPort getGuardianPort;
+
+    private NotificationEmailAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        adapter = new NotificationEmailAdapter(sendEmailPort, getGuardianPort);
+    }
+
+    @Test
+    void whenSendingNotification_thenDelegatesToSendEmailPort() {
+        UUID guardianId = UUID.randomUUID();
+        Notification notification = new Notification(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), guardianId, "PENDING", null, null, null);
+        Guardian guardian = new Guardian(guardianId, "John", "john@example.com");
+        Mockito.when(getGuardianPort.getGuardian(guardianId)).thenReturn(Optional.of(guardian));
+
+        adapter.sendNotificationEmail(notification);
+
+        Mockito.verify(sendEmailPort).sendEmail(Mockito.anyString(), Mockito.eq("john@example.com"), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    void whenSendEmailPortBeanPresent_thenBeanCreated() {
+        ApplicationContextRunner runner = new ApplicationContextRunner()
+                .withBean(SendEmailPort.class, () -> sendEmailPort)
+                .withBean(GetGuardianPort.class, () -> getGuardianPort)
+                .withUserConfiguration(NotificationEmailAdapter.class);
+
+        runner.run(context -> assertThat(context).hasSingleBean(NotificationEmailAdapter.class));
+    }
+
+    @Test
+    void whenAnotherNotificationEmailPortBean_thenAdapterNotCreated() {
+        ApplicationContextRunner runner = new ApplicationContextRunner()
+                .withBean(SendEmailPort.class, () -> sendEmailPort)
+                .withBean(GetGuardianPort.class, () -> getGuardianPort)
+                .withBean(NotificationEmailPort.class, () -> Mockito.mock(NotificationEmailPort.class))
+                .withUserConfiguration(NotificationEmailAdapter.class);
+
+        runner.run(context -> assertThat(context).doesNotHaveBean(NotificationEmailAdapter.class));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add NotificationEmailAdapter to send notification emails using SendEmailPort
- fetch guardian data via GetGuardianPort and guard missing beans
- test NotificationEmailAdapter for email dispatch and bean conditional creation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9030ac3c832991720bd8c715534d