### PR TITLE
Add authorization expiry date

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
@@ -52,7 +52,8 @@ public class AuthorizationController {
         if (!StringUtils.hasText(request.title())
                 || !StringUtils.hasText(request.text())
                 || !StringUtils.hasText(request.status())
-                || !StringUtils.hasText(request.createdBy())) {
+                || !StringUtils.hasText(request.createdBy())
+                || request.expiresAt() == null) {
             logger.warn("Missing required field when creating authorization");
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
@@ -71,7 +72,8 @@ public class AuthorizationController {
                     request.status(),
                     request.createdBy(),
                     request.sentBy(),
-                    request.approvedBy()
+                    request.approvedBy(),
+                    request.expiresAt()
             );
             return ResponseEntity.status(HttpStatus.CREATED).body(authorization);
         } catch (UserNotFoundException ex) {

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/CreateAuthorizationRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/CreateAuthorizationRequest.java
@@ -6,5 +6,6 @@ public record CreateAuthorizationRequest(
         String status,
         String createdBy,
         String sentBy,
-        String approvedBy
+        String approvedBy,
+        java.time.Instant expiresAt
 ) {}

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Authorization.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Authorization.java
@@ -45,6 +45,9 @@ public class Authorization implements Serializable {
     @Column(name = "approved_by")
     private String approvedBy;
 
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
 
@@ -74,4 +77,7 @@ public class Authorization implements Serializable {
 
     public String getApprovedBy() { return approvedBy; }
     public void setApprovedBy(String approvedBy) { this.approvedBy = approvedBy; }
+
+    public Instant getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -95,11 +95,13 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         entity.setSentBy(authorization.sentBy());
         entity.setApprovedAt(authorization.approvedAt());
         entity.setApprovedBy(authorization.approvedBy());
+        entity.setExpiresAt(authorization.expiresAt());
 
         com.xavelo.template.render.api.adapter.out.jdbc.Authorization saved = authorizationRepository.save(entity);
 
         return new Authorization(saved.getId(), saved.getTitle(), saved.getText(), saved.getStatus(), saved.getCreatedAt(),
-                saved.getCreatedBy(), saved.getSentAt(), saved.getSentBy(), saved.getApprovedAt(), saved.getApprovedBy(), List.of());
+                saved.getCreatedBy(), saved.getSentAt(), saved.getSentBy(), saved.getApprovedAt(), saved.getApprovedBy(),
+                saved.getExpiresAt(), List.of());
     }
 
     @Override
@@ -107,7 +109,8 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         logger.debug("postgress query authorizations...");
         return authorizationRepository.findAll().stream()
                 .map(a -> new Authorization(a.getId(), a.getTitle(), a.getText(), a.getStatus(), a.getCreatedAt(),
-                        a.getCreatedBy(), a.getSentAt(), a.getSentBy(), a.getApprovedAt(), a.getApprovedBy(), List.of()))
+                        a.getCreatedBy(), a.getSentAt(), a.getSentBy(), a.getApprovedAt(), a.getApprovedBy(),
+                        a.getExpiresAt(), List.of()))
                 .toList();
     }
 
@@ -120,7 +123,8 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
                             .map(AuthorizationStudent::getStudentId)
                             .toList();
                     return new Authorization(a.getId(), a.getTitle(), a.getText(), a.getStatus(), a.getCreatedAt(),
-                            a.getCreatedBy(), a.getSentAt(), a.getSentBy(), a.getApprovedAt(), a.getApprovedBy(), studentIds);
+                            a.getCreatedBy(), a.getSentAt(), a.getSentBy(), a.getApprovedAt(), a.getApprovedBy(),
+                            a.getExpiresAt(), studentIds);
                 });
     }
 

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/CreateAuthorizationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/CreateAuthorizationUseCase.java
@@ -1,7 +1,9 @@
 package com.xavelo.template.render.api.application.port.in;
 
 import com.xavelo.template.render.api.domain.Authorization;
+import java.time.Instant;
 
 public interface CreateAuthorizationUseCase {
-    Authorization createAuthorization(String title, String text, String status, String createdBy, String sentBy, String approvedBy);
+    Authorization createAuthorization(String title, String text, String status, String createdBy, String sentBy,
+                                      String approvedBy, Instant expiresAt);
 }

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -57,14 +57,15 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     }
 
     @Override
-    public Authorization createAuthorization(String title, String text, String status, String createdBy, String sentBy, String approvedBy) {
+    public Authorization createAuthorization(String title, String text, String status, String createdBy, String sentBy,
+                                             String approvedBy, Instant expiresAt) {
         UUID createdByUuid = UUID.fromString(createdBy);
         if (getUserPort.getUser(createdByUuid).isEmpty()) {
             throw new UserNotFoundException(createdByUuid);
         }
 
         Authorization authorization = new Authorization(UUID.randomUUID(), title, text, status, null, createdBy, null, sentBy,
-                null, approvedBy, List.of());
+                null, approvedBy, expiresAt, List.of());
         return createAuthorizationPort.createAuthorization(authorization);
     }
 

--- a/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
@@ -15,5 +15,6 @@ public record Authorization(
         String sentBy,
         Instant approvedAt,
         String approvedBy,
+        Instant expiresAt,
         List<UUID> studentIds
 ) {}

--- a/src/main/resources/db/migration/V11__add_expires_at_to_authorization_table.sql
+++ b/src/main/resources/db/migration/V11__add_expires_at_to_authorization_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "authorization" ADD COLUMN expires_at TIMESTAMPTZ NOT NULL;

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
@@ -53,7 +53,8 @@ class AuthorizationControllerTest {
                 {
                   \"title\": \"Title\",
                   \"status\": \"draft\",
-                  \"createdBy\": \"00000000-0000-0000-0000-000000000000\"
+                  \"createdBy\": \"00000000-0000-0000-0000-000000000000\",
+                  \"expiresAt\": \"2030-01-01T00:00:00Z\"
                 }
                 """;
 
@@ -65,8 +66,8 @@ class AuthorizationControllerTest {
 
     @Test
     void whenAllRequiredFieldsProvided_thenReturnsCreated() throws Exception {
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), "00000000-0000-0000-0000-000000000000", null, null, null, null, List.of());
-        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(), any(), any()))
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), "00000000-0000-0000-0000-000000000000", null, null, null, null, Instant.now().plusSeconds(3600), List.of());
+        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(authorization);
 
         String json = """
@@ -74,7 +75,8 @@ class AuthorizationControllerTest {
                   \"title\": \"Title\",
                   \"text\": \"Text\",
                   \"status\": \"draft\",
-                  \"createdBy\": \"00000000-0000-0000-0000-000000000000\"
+                  \"createdBy\": \"00000000-0000-0000-0000-000000000000\",
+                  \"expiresAt\": \"2030-01-01T00:00:00Z\"
                 }
                 """;
 
@@ -91,7 +93,8 @@ class AuthorizationControllerTest {
                   \"title\": \"Title\",
                   \"text\": \"Text\",
                   \"status\": \"draft\",
-                  \"createdBy\": \"not-a-uuid\"
+                  \"createdBy\": \"not-a-uuid\",
+                  \"expiresAt\": \"2030-01-01T00:00:00Z\"
                 }
                 """;
 
@@ -103,7 +106,7 @@ class AuthorizationControllerTest {
 
     @Test
     void whenCreatedByUserDoesNotExist_thenReturnsConflict() throws Exception {
-        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(), any(), any()))
+        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(), any(), any(), any()))
                 .thenThrow(new UserNotFoundException(UUID.randomUUID()));
 
         String json = """
@@ -111,7 +114,8 @@ class AuthorizationControllerTest {
                   \"title\": \"Title\",
                   \"text\": \"Text\",
                   \"status\": \"draft\",
-                  \"createdBy\": \"00000000-0000-0000-0000-000000000000\"
+                  \"createdBy\": \"00000000-0000-0000-0000-000000000000\",
+                  \"expiresAt\": \"2030-01-01T00:00:00Z\"
                 }
                 """;
 
@@ -141,7 +145,7 @@ class AuthorizationControllerTest {
 
     @Test
     void whenListingAuthorizations_thenReturnsOk() throws Exception {
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), "user1", null, null, null, null, List.of());
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), "user1", null, null, null, null, Instant.now().plusSeconds(3600), List.of());
         Mockito.when(listAuthorizationsUseCase.listAuthorizations()).thenReturn(List.of(authorization));
 
         mockMvc.perform(get("/api/authorizations"))
@@ -152,7 +156,7 @@ class AuthorizationControllerTest {
     void whenGettingAuthorization_thenReturnsStudents() throws Exception {
         UUID authorizationId = UUID.randomUUID();
         UUID studentId = UUID.randomUUID();
-        Authorization authorization = new Authorization(authorizationId, "Title", "Text", "draft", Instant.now(), "user1", null, null, null, null, List.of(studentId));
+        Authorization authorization = new Authorization(authorizationId, "Title", "Text", "draft", Instant.now(), "user1", null, null, null, null, Instant.now().plusSeconds(3600), List.of(studentId));
         Mockito.when(getAuthorizationUseCase.getAuthorization(authorizationId)).thenReturn(java.util.Optional.of(authorization));
 
         mockMvc.perform(get("/api/authorization/" + authorizationId))

--- a/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -61,17 +62,17 @@ class AuthorizationServiceTest {
         Mockito.when(getUserPort.getUser(UUID.fromString(createdBy))).thenReturn(Optional.empty());
 
         assertThrows(UserNotFoundException.class, () ->
-                authorizationService.createAuthorization("Title", "Text", "draft", createdBy, null, null));
+                authorizationService.createAuthorization("Title", "Text", "draft", createdBy, null, null, Instant.now()));
     }
 
     @Test
     void whenCreatedByUserExists_thenCreatesAuthorization() {
         String createdBy = UUID.randomUUID().toString();
         Mockito.when(getUserPort.getUser(UUID.fromString(createdBy))).thenReturn(Optional.of(new User(UUID.fromString(createdBy), "name")));
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", null, createdBy, null, null, null, null, java.util.List.of());
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", null, createdBy, null, null, null, null, Instant.now(), java.util.List.of());
         Mockito.when(createAuthorizationPort.createAuthorization(Mockito.any())).thenReturn(authorization);
 
-        Authorization result = authorizationService.createAuthorization("Title", "Text", "draft", createdBy, null, null);
+        Authorization result = authorizationService.createAuthorization("Title", "Text", "draft", createdBy, null, null, Instant.now());
         assertEquals(authorization, result);
     }
 


### PR DESCRIPTION
## Summary
- allow defining an expiration timestamp when creating an authorization
- persist the expires_at field and expose it through API

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9b964ccc8329b65fda46cf3c27e3