### PR TITLE
feat: default database configuration

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,9 +10,9 @@ spring:
           issuer-uri: https://http://192.168.1.139:32080/realms/xavelo
           jwk-set-uri: https://http://192.168.1.139:32080/realms/xavelo/protocol/openid-connect/certs
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASS}
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/postgres}
+    username: ${DB_USER:postgres}
+    password: ${DB_PASS:postgres}
     driver-class-name: org.postgresql.Driver
   flyway:
     locations: classpath:db/migration


### PR DESCRIPTION
## Summary
- provide default Postgres connection details when DB_* env vars are absent

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bca0d36f54832989a2a870130f2076