### PR TITLE
feat: default database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,20 @@ Run the tests:
 ./mvnw test
 ```
 
-Start the application with a PostgreSQL database by providing connection details via environment variables:
+The application uses an in-memory H2 database by default.
+
+To run against PostgreSQL, provide connection details via environment variables:
 
 ```bash
 export DB_URL=jdbc:postgresql://localhost:5432/postgres
 export DB_USER=postgres
 export DB_PASS=postgres
+export DB_DRIVER=org.postgresql.Driver
+export FLYWAY_ENABLED=true
 ./mvnw spring-boot:run
 ```
 
-For local development without PostgreSQL, an in-memory H2 profile is available:
-
-```bash
-SPRING_PROFILES_ACTIVE=h2 ./mvnw spring-boot:run
-```
-
-The H2 console is enabled at `http://localhost:8080/h2-console` when using this profile.
+The H2 console is enabled at `http://localhost:8080/h2-console`.
 
 Build and run the Docker image:
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,12 +10,13 @@ spring:
           issuer-uri: https://http://192.168.1.139:32080/realms/xavelo
           jwk-set-uri: https://http://192.168.1.139:32080/realms/xavelo/protocol/openid-connect/certs
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASS}
-    driver-class-name: org.postgresql.Driver
+    url: ${DB_URL:jdbc:h2:mem:appdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL}
+    username: ${DB_USER:sa}
+    password: ${DB_PASS:}
+    driver-class-name: ${DB_DRIVER:org.h2.Driver}
   flyway:
     locations: classpath:db/migration
+    enabled: ${FLYWAY_ENABLED:false}
   jpa:
     open-in-view: false
     hibernate:


### PR DESCRIPTION
## Summary
- default to an in-memory H2 datasource when DB_* env vars are absent
- document H2 default and how to switch to PostgreSQL

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bca0d36f54832989a2a870130f2076