### PR TITLE
Add NoOp email adapter fallback

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/out/email/NoOpEmailAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/email/NoOpEmailAdapter.java
@@ -1,0 +1,21 @@
+package com.xavelo.template.render.api.adapter.out.email;
+
+import com.xavelo.template.render.api.application.port.out.NotificationEmailPort;
+import com.xavelo.template.render.api.domain.Notification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(JavaMailSender.class)
+public class NoOpEmailAdapter implements NotificationEmailPort {
+
+    private static final Logger logger = LoggerFactory.getLogger(NoOpEmailAdapter.class);
+
+    @Override
+    public void sendNotificationEmail(Notification notification) {
+        logger.info("NoOpEmailAdapter - email not sent: {}", notification);
+    }
+}

--- a/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceInitializationTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceInitializationTest.java
@@ -1,0 +1,51 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.adapter.out.email.NoOpEmailAdapter;
+import com.xavelo.template.render.api.application.port.out.NotificationPort;
+import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+class NotificationServiceInitializationTest {
+
+    @Test
+    void notificationServiceStartsWithoutMailSender() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.register(NoOpEmailAdapter.class, NotificationService.class, TestConfig.class);
+        context.refresh();
+        context.getBean(NotificationService.class);
+        context.close();
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        NotificationPort notificationPort() {
+            return new NotificationPort() {
+                @Override
+                public void createNotification(Notification notification) {
+                }
+
+                @Override
+                public List<Notification> listNotifications(UUID authorizationId) {
+                    return List.of();
+                }
+
+                @Override
+                public void markNotificationSent(UUID notificationId, Instant sentAt) {
+                }
+
+                @Override
+                public void respondToNotification(UUID notificationId, NotificationStatus status, Instant respondedAt, String respondedBy) {
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add NoOpEmailAdapter bean when JavaMailSender is missing
- add test confirming NotificationService initializes without mail sender

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9e9346d08329898f2f446d1c91cd