### PR TITLE
Add scheduled job to expire notifications

### DIFF
--- a/src/main/java/com/xavelo/template/TemplateApiRenderApplication.java
+++ b/src/main/java/com/xavelo/template/TemplateApiRenderApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TemplateApiRenderApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/NotificationRepository.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/NotificationRepository.java
@@ -6,7 +6,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.UUID;
 
+import com.xavelo.template.render.api.domain.NotificationStatus;
+
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
     List<Notification> findByAuthorizationId(UUID authorizationId);
+    List<Notification> findByStatus(NotificationStatus status);
 }

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -262,4 +262,20 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         });
     }
 
+    @Override
+    public List<Notification> listNotificationsByStatus(NotificationStatus status) {
+        return notificationRepository.findByStatus(status).stream()
+                .map(n -> new Notification(n.getId(), n.getAuthorizationId(), n.getStudentId(),
+                        n.getGuardianId(), n.getStatus(), n.getSentAt(), n.getRespondedAt(), n.getRespondedBy()))
+                .toList();
+    }
+
+    @Override
+    public void expireNotification(UUID notificationId) {
+        notificationRepository.findById(notificationId).ifPresent(n -> {
+            n.setStatus(NotificationStatus.EXPIRED);
+            notificationRepository.save(n);
+        });
+    }
+
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
@@ -12,4 +12,6 @@ public interface NotificationPort {
     List<Notification> listNotifications(UUID authorizationId);
     void markNotificationSent(UUID notificationId, Instant sentAt);
     void respondToNotification(UUID notificationId, NotificationStatus status, Instant respondedAt, String respondedBy);
+    List<Notification> listNotificationsByStatus(NotificationStatus status);
+    void expireNotification(UUID notificationId);
 }

--- a/src/main/java/com/xavelo/template/render/api/application/service/NotificationExpirationJob.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/NotificationExpirationJob.java
@@ -1,0 +1,38 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.application.port.out.NotificationPort;
+import com.xavelo.template.render.api.application.port.out.GetAuthorizationPort;
+import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Component
+public class NotificationExpirationJob {
+
+    private final NotificationPort notificationPort;
+    private final GetAuthorizationPort getAuthorizationPort;
+
+    public NotificationExpirationJob(NotificationPort notificationPort, GetAuthorizationPort getAuthorizationPort) {
+        this.notificationPort = notificationPort;
+        this.getAuthorizationPort = getAuthorizationPort;
+    }
+
+    @Scheduled(cron = "0 0 23 * * *")
+    public void expireNotifications() {
+        LocalDate today = LocalDate.now(ZoneId.systemDefault());
+        List<Notification> notifications = notificationPort.listNotificationsByStatus(NotificationStatus.SENT);
+        for (Notification notification : notifications) {
+            getAuthorizationPort.getAuthorization(notification.authorizationId()).ifPresent(authorization -> {
+                LocalDate expiry = authorization.expiresAt().atZone(ZoneId.systemDefault()).toLocalDate();
+                if (expiry.equals(today)) {
+                    notificationPort.expireNotification(notification.id());
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/xavelo/template/render/api/domain/NotificationStatus.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/NotificationStatus.java
@@ -4,5 +4,5 @@ public enum NotificationStatus {
     SENT,
     APPROVED,
     REJECT,
-    EXPIRE
+    EXPIRED
 }

--- a/src/main/resources/db/migration/V10__create_notification_status_table.sql
+++ b/src/main/resources/db/migration/V10__create_notification_status_table.sql
@@ -6,7 +6,7 @@ INSERT INTO "notification_status" (code) VALUES
     ('SENT'),
     ('APPROVED'),
     ('REJECT'),
-    ('EXPIRE');
+    ('EXPIRED');
 
 ALTER TABLE "notification"
     ADD CONSTRAINT fk_notification_status

--- a/src/test/java/com/xavelo/template/render/api/application/service/NotificationExpirationJobTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/NotificationExpirationJobTest.java
@@ -1,0 +1,50 @@
+package com.xavelo.template.render.api.application.service;
+
+import com.xavelo.template.render.api.application.port.out.GetAuthorizationPort;
+import com.xavelo.template.render.api.application.port.out.NotificationPort;
+import com.xavelo.template.render.api.domain.Authorization;
+import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+class NotificationExpirationJobTest {
+
+    @Mock
+    private NotificationPort notificationPort;
+    @Mock
+    private GetAuthorizationPort getAuthorizationPort;
+
+    private NotificationExpirationJob job;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        job = new NotificationExpirationJob(notificationPort, getAuthorizationPort);
+    }
+
+    @Test
+    void expireNotifications_shouldUpdateStatusWhenAuthorizationExpiresToday() {
+        UUID authorizationId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+        Notification notification = new Notification(notificationId, authorizationId, UUID.randomUUID(), UUID.randomUUID(),
+                NotificationStatus.SENT, Instant.now(), null, null);
+        Mockito.when(notificationPort.listNotificationsByStatus(NotificationStatus.SENT))
+                .thenReturn(List.of(notification));
+        Authorization authorization = new Authorization(authorizationId, "", "", "", null, "", null, "", null, "",
+                Instant.now(), List.of());
+        Mockito.when(getAuthorizationPort.getAuthorization(authorizationId)).thenReturn(Optional.of(authorization));
+
+        job.expireNotifications();
+
+        Mockito.verify(notificationPort).expireNotification(notificationId);
+    }
+}

--- a/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceInitializationTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceInitializationTest.java
@@ -45,6 +45,15 @@ class NotificationServiceInitializationTest {
                 @Override
                 public void respondToNotification(UUID notificationId, NotificationStatus status, Instant respondedAt, String respondedBy) {
                 }
+
+                @Override
+                public List<Notification> listNotificationsByStatus(NotificationStatus status) {
+                    return List.of();
+                }
+
+                @Override
+                public void expireNotification(UUID notificationId) {
+                }
             };
         }
     }


### PR DESCRIPTION
## Summary
- add EXPIRED notification status and scheduled job running daily at 11pm to transition SENT notifications whose authorization expires today
- expose repository and port methods to list notifications by status and expire them
- enable scheduling and update migration along with unit tests for expiration

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac35a7fc83298298009112caa0e9