### PR TITLE
Add foreign key for authorization created_by

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
@@ -58,8 +58,9 @@ public class AuthorizationController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
 
+        UUID createdBy;
         try {
-            UUID.fromString(request.createdBy());
+            createdBy = UUID.fromString(request.createdBy());
         } catch (IllegalArgumentException ex) {
             logger.warn("Invalid created_by when creating authorization");
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
@@ -70,7 +71,7 @@ public class AuthorizationController {
                     request.title(),
                     request.text(),
                     "CREATED",
-                    request.createdBy(),
+                    createdBy,
                     request.sentBy(),
                     request.approvedBy(),
                     request.expiresAt()

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Authorization.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/Authorization.java
@@ -31,7 +31,7 @@ public class Authorization implements Serializable {
     private Instant createdAt;
 
     @Column(name = "created_by", nullable = false)
-    private String createdBy;
+    private UUID createdBy;
 
     @Column(name = "sent_at")
     private Instant sentAt;
@@ -63,8 +63,8 @@ public class Authorization implements Serializable {
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
 
-    public String getCreatedBy() { return createdBy; }
-    public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+    public UUID getCreatedBy() { return createdBy; }
+    public void setCreatedBy(UUID createdBy) { this.createdBy = createdBy; }
 
     public Instant getSentAt() { return sentAt; }
     public void setSentAt(Instant sentAt) { this.sentAt = sentAt; }

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/CreateAuthorizationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/CreateAuthorizationUseCase.java
@@ -2,8 +2,9 @@ package com.xavelo.template.render.api.application.port.in;
 
 import com.xavelo.template.render.api.domain.Authorization;
 import java.time.Instant;
+import java.util.UUID;
 
 public interface CreateAuthorizationUseCase {
-    Authorization createAuthorization(String title, String text, String status, String createdBy, String sentBy,
+    Authorization createAuthorization(String title, String text, String status, UUID createdBy, String sentBy,
                                       String approvedBy, Instant expiresAt);
 }

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -57,11 +57,10 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     }
 
     @Override
-    public Authorization createAuthorization(String title, String text, String status, String createdBy, String sentBy,
+    public Authorization createAuthorization(String title, String text, String status, UUID createdBy, String sentBy,
                                              String approvedBy, Instant expiresAt) {
-        UUID createdByUuid = UUID.fromString(createdBy);
-        if (getUserPort.getUser(createdByUuid).isEmpty()) {
-            throw new UserNotFoundException(createdByUuid);
+        if (getUserPort.getUser(createdBy).isEmpty()) {
+            throw new UserNotFoundException(createdBy);
         }
 
         Authorization authorization = new Authorization(UUID.randomUUID(), title, text, status, null, createdBy, null, sentBy,

--- a/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
@@ -10,7 +10,7 @@ public record Authorization(
         String text,
         String status,
         Instant createdAt,
-        String createdBy,
+        UUID createdBy,
         Instant sentAt,
         String sentBy,
         Instant approvedAt,

--- a/src/main/resources/db/migration/V12__add_created_by_foreign_key_to_authorization_table.sql
+++ b/src/main/resources/db/migration/V12__add_created_by_foreign_key_to_authorization_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "authorization"
+    ALTER COLUMN created_by TYPE UUID USING created_by::uuid;
+
+ALTER TABLE "authorization"
+    ADD CONSTRAINT fk_authorization_created_by FOREIGN KEY (created_by) REFERENCES "user"(id);

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
@@ -66,8 +66,8 @@ class AuthorizationControllerTest {
 
     @Test
     void whenAllRequiredFieldsProvided_thenReturnsCreated() throws Exception {
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), "00000000-0000-0000-0000-000000000000", null, null, null, null, Instant.now().plusSeconds(3600), List.of());
-        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(), any(), any(), any()))
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), UUID.fromString("00000000-0000-0000-0000-000000000000"), null, null, null, null, Instant.now().plusSeconds(3600), List.of());
+        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(UUID.class), any(), any(), any()))
                 .thenReturn(authorization);
 
         String json = """
@@ -106,7 +106,7 @@ class AuthorizationControllerTest {
 
     @Test
     void whenCreatedByUserDoesNotExist_thenReturnsConflict() throws Exception {
-        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(), any(), any(), any()))
+        Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(UUID.class), any(), any(), any()))
                 .thenThrow(new UserNotFoundException(UUID.randomUUID()));
 
         String json = """
@@ -145,7 +145,7 @@ class AuthorizationControllerTest {
 
     @Test
     void whenListingAuthorizations_thenReturnsOk() throws Exception {
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), "user1", null, null, null, null, Instant.now().plusSeconds(3600), List.of());
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), UUID.randomUUID(), null, null, null, null, Instant.now().plusSeconds(3600), List.of());
         Mockito.when(listAuthorizationsUseCase.listAuthorizations()).thenReturn(List.of(authorization));
 
         mockMvc.perform(get("/api/authorizations"))
@@ -156,7 +156,7 @@ class AuthorizationControllerTest {
     void whenGettingAuthorization_thenReturnsStudents() throws Exception {
         UUID authorizationId = UUID.randomUUID();
         UUID studentId = UUID.randomUUID();
-        Authorization authorization = new Authorization(authorizationId, "Title", "Text", "draft", Instant.now(), "user1", null, null, null, null, Instant.now().plusSeconds(3600), List.of(studentId));
+        Authorization authorization = new Authorization(authorizationId, "Title", "Text", "draft", Instant.now(), UUID.randomUUID(), null, null, null, null, Instant.now().plusSeconds(3600), List.of(studentId));
         Mockito.when(getAuthorizationUseCase.getAuthorization(authorizationId)).thenReturn(java.util.Optional.of(authorization));
 
         mockMvc.perform(get("/api/authorization/" + authorizationId))

--- a/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
@@ -58,8 +58,8 @@ class AuthorizationServiceTest {
 
     @Test
     void whenCreatedByUserDoesNotExist_thenThrowsConflict() {
-        String createdBy = UUID.randomUUID().toString();
-        Mockito.when(getUserPort.getUser(UUID.fromString(createdBy))).thenReturn(Optional.empty());
+        UUID createdBy = UUID.randomUUID();
+        Mockito.when(getUserPort.getUser(createdBy)).thenReturn(Optional.empty());
 
         assertThrows(UserNotFoundException.class, () ->
                 authorizationService.createAuthorization("Title", "Text", "draft", createdBy, null, null, Instant.now()));
@@ -67,8 +67,8 @@ class AuthorizationServiceTest {
 
     @Test
     void whenCreatedByUserExists_thenCreatesAuthorization() {
-        String createdBy = UUID.randomUUID().toString();
-        Mockito.when(getUserPort.getUser(UUID.fromString(createdBy))).thenReturn(Optional.of(new User(UUID.fromString(createdBy), "name")));
+        UUID createdBy = UUID.randomUUID();
+        Mockito.when(getUserPort.getUser(createdBy)).thenReturn(Optional.of(new User(createdBy, "name")));
         Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", null, createdBy, null, null, null, null, Instant.now(), java.util.List.of());
         Mockito.when(createAuthorizationPort.createAuthorization(Mockito.any())).thenReturn(authorization);
 


### PR DESCRIPTION
## Summary
- enforce `created_by` references valid user through new migration
- update authorization domain and persistence to use `UUID` user IDs
- adjust service and controller to validate users

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd300b9f708329b1893e2a27f7fe14