### PR TITLE
Decouple notification sending from student assignment

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationController.java
@@ -5,10 +5,10 @@ import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
+import com.xavelo.template.render.api.application.port.in.SendNotificationsUseCase;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
 import com.xavelo.template.render.api.domain.Authorization;
 import com.xavelo.template.render.api.domain.Notification;
-import com.xavelo.template.render.api.domain.NotificationStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
@@ -35,17 +35,20 @@ public class AuthorizationController {
     private final ListAuthorizationsUseCase listAuthorizationsUseCase;
     private final GetAuthorizationUseCase getAuthorizationUseCase;
     private final NotificationUseCase notificationUseCase;
+    private final SendNotificationsUseCase sendNotificationsUseCase;
 
     public AuthorizationController(CreateAuthorizationUseCase createAuthorizationUseCase,
                                    AssignStudentsToAuthorizationUseCase assignStudentsToAuthorizationUseCase,
                                    ListAuthorizationsUseCase listAuthorizationsUseCase,
                                    GetAuthorizationUseCase getAuthorizationUseCase,
-                                   NotificationUseCase notificationUseCase) {
+                                   NotificationUseCase notificationUseCase,
+                                   SendNotificationsUseCase sendNotificationsUseCase) {
         this.createAuthorizationUseCase = createAuthorizationUseCase;
         this.assignStudentsToAuthorizationUseCase = assignStudentsToAuthorizationUseCase;
         this.listAuthorizationsUseCase = listAuthorizationsUseCase;
         this.getAuthorizationUseCase = getAuthorizationUseCase;
         this.notificationUseCase = notificationUseCase;
+        this.sendNotificationsUseCase = sendNotificationsUseCase;
     }
 
     @PostMapping("/authorization")
@@ -106,6 +109,12 @@ public class AuthorizationController {
     public ResponseEntity<List<Notification>> listNotifications(@PathVariable UUID authorizationId) {
         List<Notification> notifications = notificationUseCase.listNotifications(authorizationId);
         return ResponseEntity.ok(notifications);
+    }
+
+    @PostMapping("/authorization/{authorizationId}/notifications/send")
+    public ResponseEntity<Void> sendNotifications(@PathVariable UUID authorizationId) {
+        sendNotificationsUseCase.sendNotifications(authorizationId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/SendNotificationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/SendNotificationUseCase.java
@@ -1,7 +1,0 @@
-package com.xavelo.template.render.api.application.port.in;
-
-import java.util.UUID;
-
-public interface SendNotificationUseCase {
-    void sendNotification(UUID authorizationId, UUID studentId, UUID guardianId);
-}

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/SendNotificationsUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/SendNotificationsUseCase.java
@@ -1,0 +1,7 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import java.util.UUID;
+
+public interface SendNotificationsUseCase {
+    void sendNotifications(UUID authorizationId);
+}

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -2,7 +2,6 @@ package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.in.AssignStudentsToAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
-import com.xavelo.template.render.api.application.port.in.SendNotificationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
@@ -36,7 +35,6 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     private final GetUserPort getUserPort;
     private final ListStudentsPort listStudentsPort;
     private final NotificationPort notificationPort;
-    private final SendNotificationUseCase sendNotificationUseCase;
 
     public AuthorizationService(CreateAuthorizationPort createAuthorizationPort,
                                 AssignStudentsToAuthorizationPort assignStudentsToAuthorizationPort,
@@ -44,8 +42,7 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
                                 GetAuthorizationPort getAuthorizationPort,
                                 GetUserPort getUserPort,
                                 ListStudentsPort listStudentsPort,
-                                NotificationPort notificationPort,
-                                SendNotificationUseCase sendNotificationUseCase) {
+                                NotificationPort notificationPort) {
         this.createAuthorizationPort = createAuthorizationPort;
         this.assignStudentsToAuthorizationPort = assignStudentsToAuthorizationPort;
         this.listAuthorizationsPort = listAuthorizationsPort;
@@ -53,7 +50,6 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
         this.getUserPort = getUserPort;
         this.listStudentsPort = listStudentsPort;
         this.notificationPort = notificationPort;
-        this.sendNotificationUseCase = sendNotificationUseCase;
     }
 
     @Override
@@ -77,7 +73,17 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
             students.stream().filter(s -> s.id().equals(studentId)).findFirst().ifPresent(student -> {
                 if (student.guardianIds() != null) {
                     for (UUID guardianId : student.guardianIds()) {
-                        sendNotificationUseCase.sendNotification(authorizationId, studentId, guardianId);
+                        Notification notification = new Notification(
+                                UUID.randomUUID(),
+                                authorizationId,
+                                studentId,
+                                guardianId,
+                                NotificationStatus.PENDING,
+                                null,
+                                null,
+                                null
+                        );
+                        notificationPort.createNotification(notification);
                     }
                 }
             });

--- a/src/main/java/com/xavelo/template/render/api/domain/NotificationStatus.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/NotificationStatus.java
@@ -1,6 +1,7 @@
 package com.xavelo.template.render.api.domain;
 
 public enum NotificationStatus {
+    PENDING,
     SENT,
     APPROVED,
     REJECT,

--- a/src/main/resources/db/migration/V10__create_notification_status_table.sql
+++ b/src/main/resources/db/migration/V10__create_notification_status_table.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS "notification_status" (
 );
 
 INSERT INTO "notification_status" (code) VALUES
+    ('PENDING'),
     ('SENT'),
     ('APPROVED'),
     ('REJECT'),

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/authorization/AuthorizationControllerTest.java
@@ -5,6 +5,7 @@ import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
+import com.xavelo.template.render.api.application.port.in.SendNotificationsUseCase;
 import com.xavelo.template.render.api.domain.Notification;
 import com.xavelo.template.render.api.domain.NotificationStatus;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -42,6 +44,9 @@ class AuthorizationControllerTest {
     @MockBean
     private NotificationUseCase notificationUseCase;
 
+    @MockBean
+    private SendNotificationsUseCase sendNotificationsUseCase;
+
     @Test
     void whenListingNotifications_thenReturnsOk() throws Exception {
         UUID authorizationId = UUID.randomUUID();
@@ -52,6 +57,14 @@ class AuthorizationControllerTest {
         mockMvc.perform(get("/api/authorization/" + authorizationId + "/notifications"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(notification.id().toString()));
+    }
+
+    @Test
+    void whenSendingNotifications_thenReturnsOk() throws Exception {
+        UUID authorizationId = UUID.randomUUID();
+        mockMvc.perform(post("/api/authorization/" + authorizationId + "/notifications/send"))
+                .andExpect(status().isOk());
+        Mockito.verify(sendNotificationsUseCase).sendNotifications(authorizationId);
     }
 
 }

--- a/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
@@ -2,7 +2,6 @@ package com.xavelo.template.render.api.application.service;
 
 import com.xavelo.template.render.api.application.port.out.AssignStudentsToAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.NotificationPort;
-import com.xavelo.template.render.api.application.port.in.SendNotificationUseCase;
 import com.xavelo.template.render.api.application.port.out.CreateAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.GetAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
@@ -43,8 +42,6 @@ class AuthorizationServiceTest {
     private ListStudentsPort listStudentsPort;
     @Mock
     private NotificationPort notificationPort;
-    @Mock
-    private SendNotificationUseCase sendNotificationUseCase;
 
     private AuthorizationService authorizationService;
 
@@ -52,8 +49,7 @@ class AuthorizationServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         authorizationService = new AuthorizationService(createAuthorizationPort, assignStudentsToAuthorizationPort,
-                listAuthorizationsPort, getAuthorizationPort, getUserPort, listStudentsPort, notificationPort,
-                sendNotificationUseCase);
+                listAuthorizationsPort, getAuthorizationPort, getUserPort, listStudentsPort, notificationPort);
     }
 
     @Test
@@ -86,7 +82,11 @@ class AuthorizationServiceTest {
 
         authorizationService.assignStudents(authorizationId, java.util.List.of(studentId));
 
-        Mockito.verify(sendNotificationUseCase).sendNotification(authorizationId, studentId, guardianId);
+        Mockito.verify(notificationPort).createNotification(Mockito.argThat(n ->
+                n.authorizationId().equals(authorizationId) &&
+                        n.studentId().equals(studentId) &&
+                        n.guardianId().equals(guardianId) &&
+                        n.status() == NotificationStatus.PENDING));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Create notifications in PENDING status when assigning students to an authorization
- Add endpoint to send all pending notifications for an authorization
- Introduce SendNotifications use case and service to dispatch pending emails

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.xavelo.template:render-api:3.3.4: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bd327ffd9c8329b87b112245052024