### PR TITLE
Add notification listing endpoints

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/notification/NotificationController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/notification/NotificationController.java
@@ -2,13 +2,16 @@ package com.xavelo.template.render.api.adapter.in.http.notification;
 
 import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
+import com.xavelo.template.render.api.domain.Notification;
 
 @RestController
 @RequestMapping("/api")
@@ -18,6 +21,18 @@ public class NotificationController {
 
     public NotificationController(NotificationUseCase notificationUseCase) {
         this.notificationUseCase = notificationUseCase;
+    }
+
+    @GetMapping("/notifications")
+    public ResponseEntity<List<Notification>> listNotifications() {
+        List<Notification> notifications = notificationUseCase.listNotifications();
+        return ResponseEntity.ok(notifications);
+    }
+
+    @GetMapping("/notifications/authorization/{authorizationId}")
+    public ResponseEntity<List<Notification>> listNotificationsByAuthorization(@PathVariable UUID authorizationId) {
+        List<Notification> notifications = notificationUseCase.listNotifications(authorizationId);
+        return ResponseEntity.ok(notifications);
     }
 
     @PostMapping("/notification/{notificationId}/sent")

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -236,6 +236,14 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
     }
 
     @Override
+    public List<Notification> listNotifications() {
+        return notificationRepository.findAll().stream()
+                .map(n -> new Notification(n.getId(), n.getAuthorizationId(), n.getStudentId(),
+                        n.getGuardianId(), n.getStatus(), n.getSentAt(), n.getRespondedAt(), n.getRespondedBy()))
+                .toList();
+    }
+
+    @Override
     public List<Notification> listNotifications(UUID authorizationId) {
         return notificationRepository.findByAuthorizationId(authorizationId).stream()
                 .map(n -> new Notification(n.getId(), n.getAuthorizationId(), n.getStudentId(),

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/NotificationUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/NotificationUseCase.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface NotificationUseCase {
+    List<Notification> listNotifications();
     List<Notification> listNotifications(UUID authorizationId);
     void markNotificationSent(UUID notificationId);
     void respondToNotification(UUID notificationId, NotificationStatus status, String respondedBy);

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/NotificationPort.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 public interface NotificationPort {
     void createNotification(Notification notification);
+    List<Notification> listNotifications();
     List<Notification> listNotifications(UUID authorizationId);
     void markNotificationSent(UUID notificationId, Instant sentAt);
     void respondToNotification(UUID notificationId, NotificationStatus status, Instant respondedAt, String respondedBy);

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -94,6 +94,11 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
     }
 
     @Override
+    public List<Notification> listNotifications() {
+        return notificationPort.listNotifications();
+    }
+
+    @Override
     public List<Notification> listNotifications(UUID authorizationId) {
         return notificationPort.listNotifications(authorizationId);
     }

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/notification/NotificationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/notification/NotificationControllerTest.java
@@ -1,6 +1,7 @@
 package com.xavelo.template.render.api.adapter.in.http.notification;
 
 import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
+import com.xavelo.template.render.api.domain.Notification;
 import com.xavelo.template.render.api.domain.NotificationStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -10,9 +11,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.UUID;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(NotificationController.class)
@@ -23,6 +27,29 @@ class NotificationControllerTest {
 
     @MockBean
     private NotificationUseCase notificationUseCase;
+
+    @Test
+    void whenListingNotifications_thenReturnsOk() throws Exception {
+        Notification notification = new Notification(UUID.randomUUID(), UUID.randomUUID(),
+                UUID.randomUUID(), UUID.randomUUID(), NotificationStatus.SENT, null, null, null);
+        Mockito.when(notificationUseCase.listNotifications()).thenReturn(List.of(notification));
+
+        mockMvc.perform(get("/api/notifications"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(notification.id().toString()));
+    }
+
+    @Test
+    void whenListingNotificationsByAuthorization_thenReturnsOk() throws Exception {
+        UUID authorizationId = UUID.randomUUID();
+        Notification notification = new Notification(UUID.randomUUID(), authorizationId,
+                UUID.randomUUID(), UUID.randomUUID(), NotificationStatus.SENT, null, null, null);
+        Mockito.when(notificationUseCase.listNotifications(authorizationId)).thenReturn(List.of(notification));
+
+        mockMvc.perform(get("/api/notifications/authorization/" + authorizationId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(notification.id().toString()));
+    }
 
     @Test
     void whenMarkingNotificationSent_thenReturnsOk() throws Exception {

--- a/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceInitializationTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/NotificationServiceInitializationTest.java
@@ -34,6 +34,11 @@ class NotificationServiceInitializationTest {
                 }
 
                 @Override
+                public List<Notification> listNotifications() {
+                    return List.of();
+                }
+
+                @Override
                 public List<Notification> listNotifications(UUID authorizationId) {
                     return List.of();
                 }


### PR DESCRIPTION
## Summary
- support listing all notifications and notifications by authorization
- expose new GET `/notifications` and `/notifications/authorization/{id}` endpoints
- cover new endpoints with MVC tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3332a6088329b6ac55c2a9750396