### PR TITLE
Mock SendNotificationsUseCase in controller tests

### DIFF
--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
@@ -6,6 +6,7 @@ import com.xavelo.template.render.api.application.port.in.NotificationUseCase;
 import com.xavelo.template.render.api.application.port.in.CreateAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.GetAuthorizationUseCase;
 import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseCase;
+import com.xavelo.template.render.api.application.port.in.SendNotificationsUseCase;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
 import com.xavelo.template.render.api.domain.Authorization;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,9 @@ class AuthorizationControllerTest {
 
     @MockBean
     private NotificationUseCase notificationUseCase;
+
+    @MockBean
+    private SendNotificationsUseCase sendNotificationsUseCase;
 
     @Test
     void whenMissingRequiredField_thenReturnsBadRequest() throws Exception {


### PR DESCRIPTION
## Summary
- Add missing SendNotificationsUseCase mock so AuthorizationController can be instantiated in secure tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.xavelo.template:render-api:3.3.4: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd34bcaefc8329bca00b4430fb1412