### PR TITLE
Include notifications in authorization retrieval

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -101,7 +101,7 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
 
         return new Authorization(saved.getId(), saved.getTitle(), saved.getText(), saved.getStatus(), saved.getCreatedAt(),
                 saved.getCreatedBy(), saved.getSentAt(), saved.getSentBy(), saved.getApprovedAt(), saved.getApprovedBy(),
-                saved.getExpiresAt(), List.of());
+                saved.getExpiresAt(), List.of(), List.of());
     }
 
     @Override
@@ -110,7 +110,7 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
         return authorizationRepository.findAll().stream()
                 .map(a -> new Authorization(a.getId(), a.getTitle(), a.getText(), a.getStatus(), a.getCreatedAt(),
                         a.getCreatedBy(), a.getSentAt(), a.getSentBy(), a.getApprovedAt(), a.getApprovedBy(),
-                        a.getExpiresAt(), List.of()))
+                        a.getExpiresAt(), List.of(), List.of()))
                 .toList();
     }
 
@@ -122,9 +122,12 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
                     List<UUID> studentIds = authorizationStudentRepository.findByAuthorizationId(authorizationId).stream()
                             .map(AuthorizationStudent::getStudentId)
                             .toList();
+                    List<UUID> notifications = notificationRepository.findByAuthorizationId(authorizationId).stream()
+                            .map(com.xavelo.template.render.api.adapter.out.jdbc.Notification::getId)
+                            .toList();
                     return new Authorization(a.getId(), a.getTitle(), a.getText(), a.getStatus(), a.getCreatedAt(),
                             a.getCreatedBy(), a.getSentAt(), a.getSentBy(), a.getApprovedAt(), a.getApprovedBy(),
-                            a.getExpiresAt(), studentIds);
+                            a.getExpiresAt(), studentIds, notifications);
                 });
     }
 

--- a/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/AuthorizationService.java
@@ -60,7 +60,7 @@ public class AuthorizationService implements CreateAuthorizationUseCase, AssignS
         }
 
         Authorization authorization = new Authorization(UUID.randomUUID(), title, text, status, null, createdBy, null, sentBy,
-                null, approvedBy, expiresAt, List.of());
+                null, approvedBy, expiresAt, List.of(), List.of());
         return createAuthorizationPort.createAuthorization(authorization);
     }
 

--- a/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
+++ b/src/main/java/com/xavelo/template/render/api/domain/Authorization.java
@@ -16,5 +16,6 @@ public record Authorization(
         Instant approvedAt,
         String approvedBy,
         Instant expiresAt,
-        List<UUID> studentIds
+        List<UUID> studentIds,
+        List<UUID> notifications
 ) {}

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/AuthorizationControllerTest.java
@@ -9,6 +9,8 @@ import com.xavelo.template.render.api.application.port.in.ListAuthorizationsUseC
 import com.xavelo.template.render.api.application.port.in.SendNotificationsUseCase;
 import com.xavelo.template.render.api.application.exception.UserNotFoundException;
 import com.xavelo.template.render.api.domain.Authorization;
+import com.xavelo.template.render.api.domain.Notification;
+import com.xavelo.template.render.api.domain.NotificationStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,7 +72,7 @@ class AuthorizationControllerTest {
 
     @Test
     void whenAllRequiredFieldsProvided_thenReturnsCreated() throws Exception {
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), UUID.fromString("00000000-0000-0000-0000-000000000000"), null, null, null, null, Instant.now().plusSeconds(3600), List.of());
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), UUID.fromString("00000000-0000-0000-0000-000000000000"), null, null, null, null, Instant.now().plusSeconds(3600), List.of(), List.of());
         Mockito.when(createAuthorizationUseCase.createAuthorization(any(), any(), any(), any(UUID.class), any(), any(), any()))
                 .thenReturn(authorization);
 
@@ -149,7 +151,7 @@ class AuthorizationControllerTest {
 
     @Test
     void whenListingAuthorizations_thenReturnsOk() throws Exception {
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), UUID.randomUUID(), null, null, null, null, Instant.now().plusSeconds(3600), List.of());
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", Instant.now(), UUID.randomUUID(), null, null, null, null, Instant.now().plusSeconds(3600), List.of(), List.of());
         Mockito.when(listAuthorizationsUseCase.listAuthorizations()).thenReturn(List.of(authorization));
 
         mockMvc.perform(get("/api/authorizations"))
@@ -157,14 +159,16 @@ class AuthorizationControllerTest {
     }
 
     @Test
-    void whenGettingAuthorization_thenReturnsStudents() throws Exception {
+    void whenGettingAuthorization_thenReturnsStudentsAndNotifications() throws Exception {
         UUID authorizationId = UUID.randomUUID();
         UUID studentId = UUID.randomUUID();
-        Authorization authorization = new Authorization(authorizationId, "Title", "Text", "draft", Instant.now(), UUID.randomUUID(), null, null, null, null, Instant.now().plusSeconds(3600), List.of(studentId));
+        Notification notification = new Notification(UUID.randomUUID(), authorizationId, studentId, UUID.randomUUID(), NotificationStatus.SENT, null, null, null);
+        Authorization authorization = new Authorization(authorizationId, "Title", "Text", "draft", Instant.now(), UUID.randomUUID(), null, null, null, null, Instant.now().plusSeconds(3600), List.of(studentId), List.of(notification.id()));
         Mockito.when(getAuthorizationUseCase.getAuthorization(authorizationId)).thenReturn(java.util.Optional.of(authorization));
 
         mockMvc.perform(get("/api/authorization/" + authorizationId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.studentIds[0]").value(studentId.toString()));
+                .andExpect(jsonPath("$.studentIds[0]").value(studentId.toString()))
+                .andExpect(jsonPath("$.notifications[0]").value(notification.id().toString()));
     }
 }

--- a/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/AuthorizationServiceTest.java
@@ -65,7 +65,7 @@ class AuthorizationServiceTest {
     void whenCreatedByUserExists_thenCreatesAuthorization() {
         UUID createdBy = UUID.randomUUID();
         Mockito.when(getUserPort.getUser(createdBy)).thenReturn(Optional.of(new User(createdBy, "name")));
-        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", null, createdBy, null, null, null, null, Instant.now(), java.util.List.of());
+        Authorization authorization = new Authorization(UUID.randomUUID(), "Title", "Text", "draft", null, createdBy, null, null, null, null, Instant.now(), java.util.List.of(), java.util.List.of());
         Mockito.when(createAuthorizationPort.createAuthorization(Mockito.any())).thenReturn(authorization);
 
         Authorization result = authorizationService.createAuthorization("Title", "Text", "draft", createdBy, null, null, Instant.now());

--- a/src/test/java/com/xavelo/template/render/api/application/service/NotificationExpirationJobTest.java
+++ b/src/test/java/com/xavelo/template/render/api/application/service/NotificationExpirationJobTest.java
@@ -40,7 +40,7 @@ class NotificationExpirationJobTest {
         Mockito.when(notificationPort.listNotificationsByStatus(NotificationStatus.SENT))
                 .thenReturn(List.of(notification));
         Authorization authorization = new Authorization(authorizationId, "", "", "", null, null, null, "", null, "",
-                Instant.now(), List.of());
+                Instant.now(), List.of(), List.of());
         Mockito.when(getAuthorizationPort.getAuthorization(authorizationId)).thenReturn(Optional.of(authorization));
 
         job.expireNotifications();


### PR DESCRIPTION
## Summary
- return notification identifiers when fetching a specific authorization
- add controller test to assert notification IDs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.xavelo.template:render-api:3.3.4: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3baa26a88329997a417e5613f814