### PR TITLE
Allow cross origin for authorizations UI

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/configuration/CorsConfig.java
+++ b/src/main/java/com/xavelo/template/render/api/configuration/CorsConfig.java
@@ -1,0 +1,15 @@
+package com.xavelo.template.render.api.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("https://authorizations-ui.onrender.com");
+    }
+}


### PR DESCRIPTION
## Summary
- apply global CORS configuration permitting https://authorizations-ui.onrender.com for all endpoints
- remove per-controller `@CrossOrigin` from `StudentController`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bda434db74832987ebeb5692c812c7