### PR TITLE
feat: allow updating guardian email

### DIFF
--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/guardian/GuardianController.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/guardian/GuardianController.java
@@ -3,6 +3,8 @@ package com.xavelo.template.render.api.adapter.in.http.guardian;
 import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
 import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
 import com.xavelo.template.render.api.application.port.in.GetGuardianUseCase;
+import com.xavelo.template.render.api.application.port.in.UpdateGuardianEmailUseCase;
+import com.xavelo.template.render.api.adapter.in.http.guardian.UpdateGuardianEmailRequest;
 import com.xavelo.template.render.api.domain.Guardian;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,11 +26,16 @@ public class GuardianController {
     private final CreateGuardianUseCase createGuardianUseCase;
     private final ListGuardiansUseCase listGuardiansUseCase;
     private final GetGuardianUseCase getGuardianUseCase;
+    private final UpdateGuardianEmailUseCase updateGuardianEmailUseCase;
 
-    public GuardianController(CreateGuardianUseCase createGuardianUseCase, ListGuardiansUseCase listGuardiansUseCase, GetGuardianUseCase getGuardianUseCase) {
+    public GuardianController(CreateGuardianUseCase createGuardianUseCase,
+                              ListGuardiansUseCase listGuardiansUseCase,
+                              GetGuardianUseCase getGuardianUseCase,
+                              UpdateGuardianEmailUseCase updateGuardianEmailUseCase) {
         this.createGuardianUseCase = createGuardianUseCase;
         this.listGuardiansUseCase = listGuardiansUseCase;
         this.getGuardianUseCase = getGuardianUseCase;
+        this.updateGuardianEmailUseCase = updateGuardianEmailUseCase;
     }
 
     @GetMapping("/guardians")
@@ -48,6 +55,19 @@ public class GuardianController {
         try {
             UUID uuid = UUID.fromString(id);
             return getGuardianUseCase.getGuardian(uuid)
+                    .map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PostMapping("/guardian/{id}/email")
+    public ResponseEntity<Guardian> updateEmail(@PathVariable String id,
+                                                @Valid @RequestBody UpdateGuardianEmailRequest request) {
+        try {
+            UUID uuid = UUID.fromString(id);
+            return updateGuardianEmailUseCase.updateEmail(uuid, request.email())
                     .map(ResponseEntity::ok)
                     .orElse(ResponseEntity.notFound().build());
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/xavelo/template/render/api/adapter/in/http/guardian/UpdateGuardianEmailRequest.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/in/http/guardian/UpdateGuardianEmailRequest.java
@@ -1,0 +1,6 @@
+package com.xavelo.template.render.api.adapter.in.http.guardian;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateGuardianEmailRequest(@NotBlank String email) {}
+

--- a/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
+++ b/src/main/java/com/xavelo/template/render/api/adapter/out/jdbc/PostgresAdapter.java
@@ -7,6 +7,7 @@ import com.xavelo.template.render.api.application.port.out.CreateUserPort;
 import com.xavelo.template.render.api.application.port.out.GetAuthorizationPort;
 import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
 import com.xavelo.template.render.api.application.port.out.GetUserPort;
+import com.xavelo.template.render.api.application.port.out.UpdateGuardianEmailPort;
 import com.xavelo.template.render.api.application.port.out.ListStudentsPort;
 import com.xavelo.template.render.api.application.port.out.ListGuardiansPort;
 import com.xavelo.template.render.api.application.port.out.ListUsersPort;
@@ -33,7 +34,7 @@ import java.util.UUID;
 
 @Component
 public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPort, CreateAuthorizationPort, ListAuthorizationsPort, GetAuthorizationPort,
-        CreateStudentPort, ListStudentsPort, CreateGuardianPort, ListGuardiansPort, GetGuardianPort, AssignStudentsToAuthorizationPort, AssignGuardiansToStudentPort,
+        CreateStudentPort, ListStudentsPort, CreateGuardianPort, ListGuardiansPort, GetGuardianPort, UpdateGuardianEmailPort, AssignStudentsToAuthorizationPort, AssignGuardiansToStudentPort,
         NotificationPort {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresAdapter.class);
@@ -222,6 +223,16 @@ public class PostgresAdapter implements ListUsersPort, GetUserPort, CreateUserPo
     public Optional<Guardian> getGuardian(UUID id) {
         return guardianRepository.findById(id)
                 .map(g -> new Guardian(g.getId(), g.getName(), g.getEmail()));
+    }
+
+    @Override
+    public Optional<Guardian> updateEmail(UUID guardianId, String email) {
+        return guardianRepository.findById(guardianId)
+                .map(entity -> {
+                    entity.setEmail(email);
+                    com.xavelo.template.render.api.adapter.out.jdbc.Guardian saved = guardianRepository.save(entity);
+                    return new Guardian(saved.getId(), saved.getName(), saved.getEmail());
+                });
     }
 
     @Override

--- a/src/main/java/com/xavelo/template/render/api/application/port/in/UpdateGuardianEmailUseCase.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/in/UpdateGuardianEmailUseCase.java
@@ -1,0 +1,11 @@
+package com.xavelo.template.render.api.application.port.in;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UpdateGuardianEmailUseCase {
+    Optional<Guardian> updateEmail(UUID guardianId, String email);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/port/out/UpdateGuardianEmailPort.java
+++ b/src/main/java/com/xavelo/template/render/api/application/port/out/UpdateGuardianEmailPort.java
@@ -1,0 +1,11 @@
+package com.xavelo.template.render.api.application.port.out;
+
+import com.xavelo.template.render.api.domain.Guardian;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UpdateGuardianEmailPort {
+    Optional<Guardian> updateEmail(UUID guardianId, String email);
+}
+

--- a/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
+++ b/src/main/java/com/xavelo/template/render/api/application/service/GuardianService.java
@@ -3,9 +3,11 @@ package com.xavelo.template.render.api.application.service;
 import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
 import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
 import com.xavelo.template.render.api.application.port.in.GetGuardianUseCase;
+import com.xavelo.template.render.api.application.port.in.UpdateGuardianEmailUseCase;
 import com.xavelo.template.render.api.application.port.out.CreateGuardianPort;
 import com.xavelo.template.render.api.application.port.out.ListGuardiansPort;
 import com.xavelo.template.render.api.application.port.out.GetGuardianPort;
+import com.xavelo.template.render.api.application.port.out.UpdateGuardianEmailPort;
 import com.xavelo.template.render.api.domain.Guardian;
 import org.springframework.stereotype.Service;
 
@@ -15,16 +17,21 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Service
-public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseCase, GetGuardianUseCase {
+public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseCase, GetGuardianUseCase, UpdateGuardianEmailUseCase {
 
     private final CreateGuardianPort createGuardianPort;
     private final ListGuardiansPort listGuardiansPort;
     private final GetGuardianPort getGuardianPort;
+    private final UpdateGuardianEmailPort updateGuardianEmailPort;
 
-    public GuardianService(CreateGuardianPort createGuardianPort, ListGuardiansPort listGuardiansPort, GetGuardianPort getGuardianPort) {
+    public GuardianService(CreateGuardianPort createGuardianPort,
+                           ListGuardiansPort listGuardiansPort,
+                           GetGuardianPort getGuardianPort,
+                           UpdateGuardianEmailPort updateGuardianEmailPort) {
         this.createGuardianPort = createGuardianPort;
         this.listGuardiansPort = listGuardiansPort;
         this.getGuardianPort = getGuardianPort;
+        this.updateGuardianEmailPort = updateGuardianEmailPort;
     }
 
     @Override
@@ -42,5 +49,11 @@ public class GuardianService implements CreateGuardianUseCase, ListGuardiansUseC
     @Override
     public Optional<Guardian> getGuardian(UUID id) {
         return getGuardianPort.getGuardian(id);
+    }
+
+    @Override
+    public Optional<Guardian> updateEmail(UUID guardianId, String email) {
+        Objects.requireNonNull(email, "email must not be null");
+        return updateGuardianEmailPort.updateEmail(guardianId, email);
     }
 }

--- a/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianControllerTest.java
+++ b/src/test/java/com/xavelo/template/render/api/adapter/in/http/secure/GuardianControllerTest.java
@@ -4,6 +4,7 @@ import com.xavelo.template.render.api.adapter.in.http.guardian.GuardianControlle
 import com.xavelo.template.render.api.application.port.in.CreateGuardianUseCase;
 import com.xavelo.template.render.api.application.port.in.GetGuardianUseCase;
 import com.xavelo.template.render.api.application.port.in.ListGuardiansUseCase;
+import com.xavelo.template.render.api.application.port.in.UpdateGuardianEmailUseCase;
 import com.xavelo.template.render.api.domain.Guardian;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +36,9 @@ class GuardianControllerTest {
     @MockBean
     private GetGuardianUseCase getGuardianUseCase;
 
+    @MockBean
+    private UpdateGuardianEmailUseCase updateGuardianEmailUseCase;
+
     @Test
     void whenListingGuardians_thenReturnsOk() throws Exception {
         List<Guardian> guardians = List.of(new Guardian(UUID.randomUUID(), "John", "john@example.com"));
@@ -61,6 +65,29 @@ class GuardianControllerTest {
     void whenCreatingGuardianWithoutEmail_thenReturnsBadRequest() throws Exception {
         String json = "{ \"name\": \"John\" }";
         mockMvc.perform(post("/api/guardian")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void whenUpdatingGuardianEmail_thenReturnsOk() throws Exception {
+        UUID id = UUID.randomUUID();
+        Guardian guardian = new Guardian(id, "John", "new@example.com");
+        when(updateGuardianEmailUseCase.updateEmail(id, "new@example.com")).thenReturn(java.util.Optional.of(guardian));
+
+        String json = "{ \"email\": \"new@example.com\" }";
+        mockMvc.perform(post("/api/guardian/" + id + "/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void whenUpdatingGuardianEmailWithoutEmail_thenReturnsBadRequest() throws Exception {
+        UUID id = UUID.randomUUID();
+        String json = "{}";
+        mockMvc.perform(post("/api/guardian/" + id + "/email")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
                 .andExpect(status().isBadRequest());


### PR DESCRIPTION
## Summary
- add `UpdateGuardianEmailRequest` and related ports
- expose endpoint to update a guardian's email
- cover controller with tests

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68bde4923f6c8329a7623a869e4746e7